### PR TITLE
Fix header footer top

### DIFF
--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,13 +1,13 @@
 <footer class="bg-main p-3 h-14 fixed bottom-0 w-full z-10">
-  <div class="container mx-auto flex justify-center items-center h-full space-x-24">
+  <div class="container mx-auto flex justify-center items-center h-full space-x-28 sm:space-x-32">
     <%= link_to root_path, class: "text-accent hover:text-hover" do %>
-      <i class="fas fa-home  text-2xl"></i>
+      <i class="fas fa-home text-xl sm:text-2xl align-middle"></i>
     <% end %>
     <%= link_to "#", class: "text-accent hover:text-hover" do %>
-      <i class="fas fa-search text-2xl"></i>
+      <i class="fas fa-search text-xl sm:text-2xl align-middle"></i>
     <% end %>
     <%= link_to "#", class: "text-accent hover:text-hover" do %>
-      <i class="fas fa-plus text-2xl"></i>
+      <i class="fas fa-plus text-xl sm:text-2xl align-middle"></i>
     <% end %>
   </div>
 </footer>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,13 +1,13 @@
-<footer class="bg-main p-4 fixed bottom-0 w-full z-10">
-  <div class="container mx-auto flex justify-center items-center space-x-8">
-    <%= link_to root_path, class: "text-text hover:text-accent" do %>
-      <i class="fas fa-home fa-lg"></i>
+<footer class="bg-main p-3 h-14 fixed bottom-0 w-full z-10">
+  <div class="container mx-auto flex justify-center items-center h-full space-x-24">
+    <%= link_to root_path, class: "text-accent hover:text-hover" do %>
+      <i class="fas fa-home  text-2xl"></i>
     <% end %>
-    <%= link_to "#", class: "text-text hover:text-accent" do %>
-      <i class="fas fa-search fa-lg"></i>
+    <%= link_to "#", class: "text-accent hover:text-hover" do %>
+      <i class="fas fa-search text-2xl"></i>
     <% end %>
-    <%= link_to "#", class: "text-text hover:text-accent" do %>
-      <i class="fas fa-plus fa-lg"></i>
+    <%= link_to "#", class: "text-accent hover:text-hover" do %>
+      <i class="fas fa-plus text-2xl"></i>
     <% end %>
   </div>
 </footer>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,11 +1,11 @@
 <header class="bg-main p-3 h-14 fixed top-0 w-full z-10">
-  <div class="container mx-auto px-6 flex justify-between h-full items-center">
-    <%= link_to root_path, class: "text-2xl font-bold text-text" do %>
+  <div class="container mx-auto px-4 sm:px-6 md:px-8 flex justify-between h-full items-center">
+    <%= link_to root_path, class: "text-xl sm:text-2xl font-bold text-text" do %>
       PurinMania
     <% end %>
     <nav>
       <%= link_to "#", class: "text-accent hover:text-hover" do %>
-        <i class="fa-solid fa-right-to-bracket text-2xl"></i>
+        <i class="fa-solid fa-right-to-bracket text-xl sm:text-2xl align-middle"></i>
       <% end %>
     </nav>
   </div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,11 +1,11 @@
-<header class="bg-main p-4 fixed top-0 w-full z-10">
-  <div class="container mx-auto flex justify-between items-center">
+<header class="bg-main p-3 h-14 fixed top-0 w-full z-10">
+  <div class="container mx-auto px-6 flex justify-between h-full items-center">
     <%= link_to root_path, class: "text-2xl font-bold text-text" do %>
       PurinMania
     <% end %>
     <nav>
-      <%= link_to "#", class: "text-text hover:text-accent" do %>
-        <i class="fas fa-user-circle fa-lg"></i>
+      <%= link_to "#", class: "text-accent hover:text-hover" do %>
+        <i class="fa-solid fa-right-to-bracket text-2xl"></i>
       <% end %>
     </nav>
   </div>

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -2,7 +2,7 @@
   <div>
     <h2 class="text-3xl font-bold text-center mb-6">自分好みのプリンを見つけよう</h2>
     <div class="text-center mb-8">
-      <%= link_to "プリンを探す", "#", class: "btn btn-primary" %>
+      <%= link_to "プリンを探す", "#", class: "btn btn-primary text-white" %>
     </div>
     <div class="bg-white p-4 rounded-lg shadow-md w-full max-w-md mx-auto">
       <h3 class="text-xl font-bold mb-2">機能説明</h3>

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -10,7 +10,7 @@
     </div>
   </div>
   
-  <div class="mt-8 flex justify-center space-x-4 mb-16">
+  <div class="mt-8 flex justify-center space-x-4 mb-0">
     <%= link_to "利用規約", "#", class: "text-accent hover:underline" %>
     <%= link_to "プライバシーポリシー", "#", class: "text-accent hover:underline" %>
     <%= link_to "お問い合わせ", "#", class: "text-accent hover:underline" %>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -11,6 +11,7 @@ module.exports = {
         main: '#FFD681',
         accent: '#9C661F',
         base: '#FFF5E6',
+        hover: '#805A27',
         text: '#2C1803',
         placeholder: '#C5B6A8',
       },


### PR DESCRIPTION
## ヘッダーフッタートップのレイアウト修正

### 共通ヘッダーフッター（ログイン前、遷移先#）

- ヘッダーフッターの大きさを指定　p-3 h-14
- アイコンホバー時の色を設定
- アイコンにalign-middleを追加
- ヘッダーのアイコンをログインアイコンに変更
- ヘッダーフッターそれぞれ要素同士の幅を端末ごとに変化するように設定

### トップページの一部修正

- リンクのmb-0にし、下部に配置
- ボタンの文字の色を白に変更

close #6 #7