### PR TITLE
not_authenticatedメソッドの削除

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,9 +10,4 @@ class ApplicationController < ActionController::Base
     devise_parameter_sanitizer.permit(:account_update, keys: [:name, :avatar])
   end
 
-  private
-
-  def not_authenticated
-    redirect_to new_user_session_path, alert: 'ログインしてください'
-  end
 end


### PR DESCRIPTION
application_controller.rbにnot_authenticatedメソッドを記述していたが、
deviseを使用している場合ログインしていないユーザーに対する処理はauthenticate_user!というデフォルトの認証メソッドが行うためnot_authenticatedメソッドの記述は必要ないので削除。

sorceryを用いる場合は必要