### PR TITLE
選択フォーム選択時のjs修正

### DIFF
--- a/app/javascript/custom/select_placeholder.js
+++ b/app/javascript/custom/select_placeholder.js
@@ -4,15 +4,11 @@ document.addEventListener('turbo:load', function() {
   selects.forEach(select => {
     const placeholder = select.querySelector('option[value=""]');
     
-    // プレースホルダーの色を設定
-    select.style.color = '#C5B6A8'; // placeholderの色
+    // 初期状態の色を設定
+    updateSelectColor(select);
 
     select.addEventListener('change', function() {
-      if (this.value) {
-        this.style.color = '#2C1803'; // 通常のテキスト色
-      } else {
-        this.style.color = '#C5B6A8'; // placeholderの色
-      }
+      updateSelectColor(this);
     });
 
     // フォーカス時の処理
@@ -30,4 +26,13 @@ document.addEventListener('turbo:load', function() {
       }
     });
   });
+
+  // 色を更新する関数
+  function updateSelectColor(select) {
+    if (select.value) {
+      select.style.color = '#2C1803'; // 通常のテキスト色
+    } else {
+      select.style.color = '#C5B6A8'; // placeholderの色
+    }
+  }
 });


### PR DESCRIPTION
検索フォームと投稿フォームにある選択フォームについて、
初期値にplaceholderの色が設定されていたため、検索フォームで選択後リロードした際にplaceholderの色に変わってしまっていた。

### 修正点
updateSelectColorという関数を作成し、ページ読み込み時からセレクトの値に基づいて適切な色を設定するように記述
初期状態の色設定:
元のコード: select.style.color = '#C5B6A8';
新しいコード: updateSelectColor(select);