### PR TITLE
削除の非同期処理バグ修正

### DIFF
--- a/app/javascript/controllers/application.js
+++ b/app/javascript/controllers/application.js
@@ -1,9 +1,12 @@
 import { Application } from "@hotwired/stimulus"
+import { Turbo } from "@hotwired/turbo-rails"
 
 const application = Application.start()
 
 // Configure Stimulus development experience
 application.debug = false
 window.Stimulus   = application
+
+Turbo.session.drive = true
 
 export { application }

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -28,7 +28,9 @@
       <%= render 'shared/before_login_header' %>
     <% end %>
     <main class="py-16">
-      <%= render 'shared/flash_messages' %>
+      <%= turbo_frame_tag "flash" do %>
+        <%= render 'shared/flash_messages' %>
+      <% end %>
       <%= yield %>
     </main>
     <%= render 'shared/footer' %>

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -1,74 +1,76 @@
-<div id="<%= dom_id(post) %>" class="card bg-white shadow-lg mb-6 mx-auto flex-shrink px-4 sm:px-0 max-w-sm sm:max-w-2xl relative">
-  <!-- 編集・削除ボタンまたはブックマーク -->
-  <% if user_signed_in? && current_user.own?(post) %>
-    <div class="absolute top-6 right-8 sm:top-6 sm:right-6 flex space-x-2 z-[5]">
-      <%= link_to edit_post_path(post), class: "text-accent hover:text-hover", id: "button-edit-#{post.id}", data: { turbo_frame: "_top" } do %>
-        <i class="fas fa-edit text-2xl"></i>
-      <% end %>
-      <%= link_to post_path(post), class: "text-accent hover:text-hover", id: "button-delete-#{post.id}", data: { turbo_method: :delete, turbo_confirm: t('defaults.delete_confirm'), turbo_frame: "_top" } do %>
-        <i class="fas fa-trash text-2xl"></i>
-      <% end %>
-    </div>
-  <% else %>
-    <div class="absolute top-6 right-8 sm:top-6 sm:right-6 flex space-x-2 z-[5]">
-      <% if user_signed_in? %>
-        <%= render 'posts/bookmark_buttons', { post: post } %>
-      <% end %>
-    </div>
-  <% end %>
-  <div class="card-body p-4 sm:p-5">
-    <div class="flex flex-wrap">
-      <div class="w-full sm:w-2/5">
-        <!-- ユーザー情報 -->
-        <div class="flex items-center mb-3">
-          <div class="w-10 h-10 rounded-full overflow-hidden mr-3">
-            <% if post.user.avatar.attached? %>
-              <%= image_tag post.user.avatar.variant(resize_to_fill: [40, 40]), class: "w-full h-full object-cover" %>
+<%= turbo_frame_tag dom_id(post) do %>
+  <div class="card bg-white shadow-lg mb-6 mx-auto flex-shrink px-4 sm:px-0 max-w-sm sm:max-w-2xl relative">
+    <!-- 編集・削除ボタンまたはブックマーク -->
+    <% if user_signed_in? && current_user.own?(post) %>
+      <div class="absolute top-6 right-8 sm:top-6 sm:right-6 flex space-x-2 z-[5]">
+        <%= link_to edit_post_path(post), class: "text-accent hover:text-hover", id: "button-edit-#{post.id}", data: { turbo_frame: "_top" } do %>
+          <i class="fas fa-edit text-2xl"></i>
+        <% end %>
+        <%= link_to post_path(post), class: "text-accent hover:text-hover", id: "button-delete-#{post.id}", data: { turbo_method: :delete, turbo_confirm: t('defaults.delete_confirm') } do %>
+          <i class="fas fa-trash text-2xl"></i>
+        <% end %>
+      </div>
+    <% else %>
+      <div class="absolute top-6 right-8 sm:top-6 sm:right-6 flex space-x-2 z-[5]">
+        <% if user_signed_in? %>
+          <%= render 'posts/bookmark_buttons', { post: post } %>
+        <% end %>
+      </div>
+    <% end %>
+    <div class="card-body p-4 sm:p-5">
+      <div class="flex flex-wrap">
+        <div class="w-full sm:w-2/5">
+          <!-- ユーザー情報 -->
+          <div class="flex items-center mb-3">
+            <div class="w-10 h-10 rounded-full overflow-hidden mr-3">
+              <% if post.user.avatar.attached? %>
+                <%= image_tag post.user.avatar.variant(resize_to_fill: [40, 40]), class: "w-full h-full object-cover" %>
+              <% else %>
+                <%= image_tag "default_avatar.webp", class: "w-full h-full object-cover" %>
+              <% end %>
+            </div>
+            <div>
+              <p class="text-sm font-semibold"><%= post.user.name %></p>
+              <p class="text-xs text-subtleText"><%= post.created_at.strftime("%Y/%m/%d") %></p>
+            </div>
+          </div>
+          <!-- 画像ー -->
+          <div class="aspect-square rounded-md overflow-hidden">
+            <% if post.image.attached? %>
+              <%= image_tag post.image.variant(resize_to_fill: [800, 800], format: :webp), class: "w-full h-full object-cover" %>
             <% else %>
-              <%= image_tag "default_avatar.webp", class: "w-full h-full object-cover" %>
+              <%= image_tag "default_image.webp", class: "w-full h-full object-cover" %>
             <% end %>
           </div>
-          <div>
-            <p class="text-sm font-semibold"><%= post.user.name %></p>
-            <p class="text-xs text-subtleText"><%= post.created_at.strftime("%Y/%m/%d") %></p>
+        </div>
+        <div class="w-full sm:w-3/5 p-4">
+          <h2 class="text-xl sm:text-2xl font-bold mb-4 sm:my-4 text-center sm:text-left">
+            <%= link_to post.shop.name, post_path(post), data: { turbo_frame: "_top" } %>
+          </h2>
+          <div class="flex justify-center sm:justify-start mb-4 space-x-1">
+            <% Post.overall_ratings.size.times do |i| %>
+              <span 
+                class="inline-block w-5 h-5 sm:w-6 sm:h-6 mask mask-star-2 <%= i < Post.overall_ratings[post.overall_rating] ? 'bg-accent' : 'bg-placeholder' %>"
+                aria-hidden="true"
+              ></span>
+            <% end %>
           </div>
-        </div>
-        <!-- 画像ー -->
-        <div class="aspect-square rounded-md overflow-hidden">
-          <% if post.image.attached? %>
-            <%= image_tag post.image.variant(resize_to_fill: [800, 800], format: :webp), class: "w-full h-full object-cover" %>
-          <% else %>
-            <%= image_tag "default_image.webp", class: "w-full h-full object-cover" %>
-          <% end %>
-        </div>
-      </div>
-      <div class="w-full sm:w-3/5 p-4">
-        <h2 class="text-xl sm:text-2xl font-bold mb-4 sm:my-4 text-center sm:text-left">
-          <%= link_to post.shop.name, post_path(post), data: { turbo_frame: "_top" } %>
-        </h2>
-        <div class="flex justify-center sm:justify-start mb-4 space-x-1">
-          <% Post.overall_ratings.size.times do |i| %>
-            <span 
-              class="inline-block w-5 h-5 sm:w-6 sm:h-6 mask mask-star-2 <%= i < Post.overall_ratings[post.overall_rating] ? 'bg-accent' : 'bg-placeholder' %>"
-              aria-hidden="true"
-            ></span>
-          <% end %>
-        </div>
-        <div class="flex flex-wrap justify-center sm:justify-start items-center mb-2 text-sm sm:text-[16px] text-center sm:text-left">
-          <div class="flex items-center">
-            <span class="font-semibold mr-1"><%= t('activerecord.attributes.post.firmness') %>:</span>
-            <span><%= I18n.t("enums.post.firmness.#{post.firmness}") %></span>
+          <div class="flex flex-wrap justify-center sm:justify-start items-center mb-2 text-sm sm:text-[16px] text-center sm:text-left">
+            <div class="flex items-center">
+              <span class="font-semibold mr-1"><%= t('activerecord.attributes.post.firmness') %>:</span>
+              <span><%= I18n.t("enums.post.firmness.#{post.firmness}") %></span>
+            </div>
+            <div class="mx-1">|</div>
+            <div class="flex items-center">
+              <span class="font-semibold mr-1"><%= t('activerecord.attributes.post.sweetness') %>:</span>
+              <span><%= I18n.t("enums.post.sweetness.#{post.sweetness}") %></span>
+            </div>
           </div>
-          <div class="mx-1">|</div>
-          <div class="flex items-center">
-            <span class="font-semibold mr-1"><%= t('activerecord.attributes.post.sweetness') %>:</span>
-            <span><%= I18n.t("enums.post.sweetness.#{post.sweetness}") %></span>
-          </div>
+          <p class="mb-2 text-sm sm:text-[16px] text-subtleText">
+            <i class="fa fa-map-marker-alt mr-2 text-accent"></i><%= post.shop&.address.present? ? post.shop.address : t('posts.address_not_registered') %>
+          <p class="text-sm sm:text-[16px]"><%= post.body.truncate(50) %></p>
         </div>
-        <p class="mb-2 text-sm sm:text-[16px] text-subtleText">
-          <i class="fa fa-map-marker-alt mr-2 text-accent"></i><%= post.shop&.address.present? ? post.shop.address : t('posts.address_not_registered') %>
-        <p class="text-sm sm:text-[16px]"><%= post.body.truncate(50) %></p>
       </div>
     </div>
   </div>
-</div>
+<% end %>

--- a/app/views/posts/destroy.turbo_stream.erb
+++ b/app/views/posts/destroy.turbo_stream.erb
@@ -1,1 +1,0 @@
-<%= turbo_stream.remove "post_#{params[:id]}" %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,84 +1,86 @@
-<div class="container mx-auto px-8 sm:px-4 py-6 sm:py-8 max-w-xl sm:max-w-2xl">
-  <div class="bg-white shadow-lg rounded-lg overflow-hidden px-6 sm:px-20 py-4 sm:py-6 md:py-10">
-    <!-- ユーザー情報とアクションボタン -->
-    <div class="p-2 sm:p-4 flex justify-between items-center mb-3 sm:mb-4">
-      <div class="flex items-center">
-        <div class="w-10 h-10 rounded-full overflow-hidden mr-3">
-          <% if @post.user.avatar.attached? %>
-            <%= image_tag @post.user.avatar.variant(resize_to_fill: [40, 40]), class: "w-full h-full object-cover" %>
-          <% else %>
-            <%= image_tag "default_avatar.webp", class: "w-full h-full object-cover" %>
-          <% end %>
+<%= turbo_frame_tag "_top" do %>
+  <div class="container mx-auto px-8 sm:px-4 py-6 sm:py-8 max-w-xl sm:max-w-2xl">
+    <div class="bg-white shadow-lg rounded-lg overflow-hidden px-6 sm:px-20 py-4 sm:py-6 md:py-10">
+      <!-- ユーザー情報とアクションボタン -->
+      <div class="p-2 sm:p-4 flex justify-between items-center mb-3 sm:mb-4">
+        <div class="flex items-center">
+          <div class="w-10 h-10 rounded-full overflow-hidden mr-3">
+            <% if @post.user.avatar.attached? %>
+              <%= image_tag @post.user.avatar.variant(resize_to_fill: [40, 40]), class: "w-full h-full object-cover" %>
+            <% else %>
+              <%= image_tag "default_avatar.webp", class: "w-full h-full object-cover" %>
+            <% end %>
+          </div>
+          <div>
+            <p class="font-semibold"><%= @post.user.name %></p>
+            <p class="text-xs text-subtleText"><%= @post.created_at.strftime("%Y/%m/%d %H:%M") %></p>
+          </div>
         </div>
-        <div>
-          <p class="font-semibold"><%= @post.user.name %></p>
-          <p class="text-xs text-subtleText"><%= @post.created_at.strftime("%Y/%m/%d %H:%M") %></p>
+        <!-- 編集・削除ボタンまたはブックマーク -->
+        <% if user_signed_in? && current_user.own?(@post) %>
+          <div class="flex space-x-2">
+            <%= link_to edit_post_path(@post), class: "text-accent hover:text-hover", id: "button-edit-#{@post.id}", data: { turbo_frame: "_top" } do %>
+              <i class="fas fa-edit text-2xl"></i>
+            <% end %>
+            <%= link_to post_path(@post), class: "text-accent hover:text-hover", id: "button-delete-#{@post.id}", data: { turbo_method: :delete, turbo_confirm: t('defaults.delete_confirm') } do %>
+              <i class="fas fa-trash text-2xl"></i>
+            <% end %>
+          </div>
+        <% else %>
+          <div class="flex space-x-2">  
+            <% if user_signed_in? %>
+              <%= render 'bookmark_buttons', { post: @post } %>
+            <% end %>
+          </div>
+        <% end %>
+      </div>
+  
+      <!-- 店舗名 -->
+      <h1 class="text-2xl font-bold my-6 text-center"><%= @post.shop.name %></h1>
+  
+      <!-- 投稿画像 -->
+      <div class="w-11/12 mx-auto aspect-square bg-gray-300 flex items-center justify-center rounded-lg mb-8 overflow-hidden">
+        <% if @post.image.attached? %>
+          <%= image_tag @post.image.variant(resize_to_fill: [1000, 1000], format: :webp), class: "w-full h-full object-cover" %>
+        <% else %>
+          <%= image_tag "default_image.webp", class: "w-full h-full object-cover" %>
+        <% end %>
+      </div>
+  
+      <!-- 評価 -->
+      <div class="flex justify-center mb-4">
+        <% Post.overall_ratings.size.times do |i| %>
+          <span 
+            class="inline-block w-6 h-6 sm:w-8 sm:h-8 md:w-10 md:h-10 mask mask-star-2 mx-1 <%= i < Post.overall_ratings[@post.overall_rating] ? 'bg-accent' : 'bg-placeholder' %>"
+            aria-hidden="true"
+          ></span>
+        <% end %>
+      </div>
+  
+      <!-- 固さと甘さ -->
+      <div class="px-4 py-2 text-center font-bold my-6">
+        <div class="flex justify-center items-center space-x-2 sm:space-x-4">
+          <span class="sm:text-lg md:text-xl lg:text-2xl">
+            固さ: <%= t("enums.post.firmness.#{@post.firmness}") %>
+          </span>
+          <span class="sm:text-lg md:text-xl lg:text-2xl">|</span>
+          <span class="sm:text-lg md:text-xl lg:text-2xl">
+            甘さ: <%= t("enums.post.sweetness.#{@post.sweetness}") %>
+          </span>
         </div>
       </div>
-      <!-- 編集・削除ボタンまたはブックマーク -->
-      <% if user_signed_in? && current_user.own?(@post) %>
-        <div class="flex space-x-2">
-          <%= link_to edit_post_path(@post), class: "text-accent hover:text-hover", id: "button-edit-#{@post.id}" do %>
-            <i class="fas fa-edit text-2xl"></i>
-          <% end %>
-          <%= link_to post_path(@post), class: "text-accent hover:text-hover", id: "button-delete-#{@post.id}", data: { turbo_method: :delete, turbo_confirm: t('defaults.delete_confirm') } do %>
-            <i class="fas fa-trash text-2xl"></i>
-          <% end %>
-        </div>
-      <% else %>
-        <div class="flex space-x-2">  
-          <% if user_signed_in? %>
-            <%= render 'bookmark_buttons', { post: @post } %>
-          <% end %>
-        </div>
-      <% end %>
-    </div>
-
-    <!-- 店舗名 -->
-    <h1 class="text-2xl font-bold my-6 text-center"><%= @post.shop.name %></h1>
-
-    <!-- 投稿画像 -->
-    <div class="w-11/12 mx-auto aspect-square bg-gray-300 flex items-center justify-center rounded-lg mb-8 overflow-hidden">
-      <% if @post.image.attached? %>
-        <%= image_tag @post.image.variant(resize_to_fill: [1000, 1000], format: :webp), class: "w-full h-full object-cover" %>
-      <% else %>
-        <%= image_tag "default_image.webp", class: "w-full h-full object-cover" %>
-      <% end %>
-    </div>
-
-    <!-- 評価 -->
-    <div class="flex justify-center mb-4">
-      <% Post.overall_ratings.size.times do |i| %>
-        <span 
-          class="inline-block w-6 h-6 sm:w-8 sm:h-8 md:w-10 md:h-10 mask mask-star-2 mx-1 <%= i < Post.overall_ratings[@post.overall_rating] ? 'bg-accent' : 'bg-placeholder' %>"
-          aria-hidden="true"
-        ></span>
-      <% end %>
-    </div>
-
-    <!-- 固さと甘さ -->
-    <div class="px-4 py-2 text-center font-bold my-6">
-      <div class="flex justify-center items-center space-x-2 sm:space-x-4">
-        <span class="sm:text-lg md:text-xl lg:text-2xl">
-          固さ: <%= t("enums.post.firmness.#{@post.firmness}") %>
-        </span>
-        <span class="sm:text-lg md:text-xl lg:text-2xl">|</span>
-        <span class="sm:text-lg md:text-xl lg:text-2xl">
-          甘さ: <%= t("enums.post.sweetness.#{@post.sweetness}") %>
-        </span>
+  
+      <!-- コメント -->
+      <div class="px-4 sm:px-6 md:px-8 lg:px-14 py-4">
+        <%= simple_format(@post.body, class: "text-sm sm:text-[16px] text-left break-words") %>
       </div>
-    </div>
-
-    <!-- コメント -->
-    <div class="px-4 sm:px-6 md:px-8 lg:px-14 py-4">
-      <%= simple_format(@post.body, class: "text-sm sm:text-[16px] text-left break-words") %>
-    </div>
-
-    <hr class="mt-6 mb-4 border-placeholder">
-
-    <!-- 住所 -->
-    <div class="px-4 pb-4 text-sm sm:text-[16px] text-subtleText">
-      <i class="fas fa-map-marker-alt mr-2 text-accent"></i><%= @post.shop&.address.present? ? @post.shop.address : t('posts.address_not_registered') %>
+  
+      <hr class="mt-6 mb-4 border-placeholder">
+  
+      <!-- 住所 -->
+      <div class="px-4 pb-4 text-sm sm:text-[16px] text-subtleText">
+        <i class="fas fa-map-marker-alt mr-2 text-accent"></i><%= @post.shop&.address.present? ? @post.shop.address : t('posts.address_not_registered') %>
+      </div>
     </div>
   </div>
-</div>
+<% end %>

--- a/config/initializers/turbo.rb
+++ b/config/initializers/turbo.rb
@@ -1,0 +1,1 @@
+Rails.application.config.turbo.custom_action_redirect = true


### PR DESCRIPTION
### 詳細ページから削除できなかったバグを修正
◾️app/controllers/posts_controller.rb
以下挙動となるように修正
- マイページ一覧からの削除：マイページの投稿一覧内で部分更新
- 詳細ページ: 投稿一覧に遷移
- 投稿一覧からの削除: 投稿一覧内で部分更新

◾️app/views/posts/_post.html.erb
<%= turbo_frame_tag dom_id(post) do %>を記述し、削除の部分更新に対応

◾️app/views/posts/show.html.erb
<%= turbo_frame_tag "_top" do %>を記述し、詳細ページからの削除後にページ全体をリロードし一覧ページに遷移するように修正


