### PR TITLE
投稿関連ページのデザイン修正

### DIFF
--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -1,8 +1,8 @@
 <%= turbo_frame_tag dom_id(post) do %>
-  <div class="card bg-white shadow-lg mb-6 mx-auto flex-shrink px-4 sm:px-0 max-w-sm sm:max-w-3xl relative">
+  <div class="card bg-white shadow-lg mb-6 mx-auto flex-shrink px-0 max-w-sm sm:max-w-2xl relative">
     <!-- 編集・削除ボタンまたはブックマーク -->
     <% if user_signed_in? && current_user.own?(post) %>
-      <div class="absolute top-7 right-9 sm:top-8 sm:right-9 flex space-x-2 z-[5]">
+      <div class="absolute top-6 right-6 flex space-x-2 z-[5]">
         <%= link_to edit_post_path(post), class: "text-accent hover:text-hover", id: "button-edit-#{post.id}", data: { turbo_frame: "_top" } do %>
           <i class="fas fa-edit text-2xl"></i>
         <% end %>
@@ -11,7 +11,7 @@
         <% end %>
       </div>
     <% else %>
-      <div class="absolute top-7 right-9 sm:top-8 sm:right-9 flex space-x-2 z-[5]">
+      <div class="absolute top-6 right-6 flex space-x-2 z-[5]">
         <% if user_signed_in? %>
           <%= render 'posts/bookmark_buttons', { post: post } %>
         <% end %>
@@ -21,21 +21,21 @@
       <div class="flex flex-wrap">
         <div class="w-full sm:w-2/5">
           <!-- ユーザー情報 -->
-          <div class="flex items-center mb-3">
-            <div class="w-10 h-10 sm:w-15 sm:h-15 rounded-full overflow-hidden mr-3 ml-0 sm:ml-2 mt-2">
+          <div class="flex items-center">
+            <div class="w-10 h-10 rounded-full overflow-hidden mr-2 flex-shrink-0">
               <% if post.user.avatar.attached? %>
-                <%= image_tag post.user.avatar.variant(resize_to_fill: [50, 50]), class: "w-full h-full object-cover" %>
+                <%= image_tag post.user.avatar.variant(resize_to_fill: [48, 48]), class: "w-full h-full object-cover" %>
               <% else %>
                 <%= image_tag "default_avatar.webp", class: "w-full h-full object-cover" %>
               <% end %>
             </div>
-            <div>
-              <p class="text-sm font-semibold"><%= post.user.name %></p>
-              <p class="text-xs text-subtleText"><%= post.created_at.strftime("%Y/%m/%d") %></p>
+            <div class="flex flex-col justify-center overflow-hidden">
+              <p class="text-sm font-semibold truncate max-w-[120px] sm:max-w-[150px]"><%= post.user.name %></p>
+              <p class="text-xs text-subtleText pl-0.5"><%= post.created_at.strftime("%Y/%m/%d") %></p>
             </div>
           </div>
           <!-- 画像ー -->
-          <div class="aspect-square rounded-md overflow-hidden">
+          <div class="aspect-square rounded-md overflow-hidden pt-4">
             <% if post.image.attached? %>
               <%= image_tag post.image.variant(resize_to_fill: [800, 800], format: :webp), class: "w-full h-full object-cover" %>
             <% else %>
@@ -44,7 +44,7 @@
           </div>
         </div>
         <div class="w-full sm:w-3/5 p-4">
-          <h2 class="text-xl sm:text-2xl font-bold mb-4 sm:mt-10 text-center sm:text-left">
+          <h2 class="text-xl sm:text-2xl font-bold mb-4 sm:mt-8 text-center sm:text-left">
             <%= link_to post.shop.name, post_path(post), data: { turbo_frame: "_top" } %>
           </h2>
           <div class="flex justify-center sm:justify-start mb-4 space-x-1">
@@ -57,13 +57,13 @@
           </div>
           <div class="flex flex-wrap justify-center sm:justify-start items-center mb-2 text-sm sm:text-[18px] text-center sm:text-left">
             <div class="flex items-center">
-              <span class="font-semibold mr-1"><%= t('activerecord.attributes.post.firmness') %>:</span>
-              <span><%= I18n.t("enums.post.firmness.#{post.firmness}") %></span>
+              <span class="font-semibold mr-1"><%= t('activerecord.attributes.post.sweetness') %>:</span>
+              <span><%= I18n.t("enums.post.sweetness.#{post.sweetness}") %></span>
             </div>
             <div class="mx-1">|</div>
             <div class="flex items-center">
-              <span class="font-semibold mr-1"><%= t('activerecord.attributes.post.sweetness') %>:</span>
-              <span><%= I18n.t("enums.post.sweetness.#{post.sweetness}") %></span>
+              <span class="font-semibold mr-1"><%= t('activerecord.attributes.post.firmness') %>:</span>
+              <span><%= I18n.t("enums.post.firmness.#{post.firmness}") %></span>
             </div>
           </div>
           <p class="mb-2 text-sm sm:text-[16px] text-subtleText">

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -3,16 +3,16 @@
     <!-- ユーザー情報とアクションボタン -->
     <div class="p-2 sm:p-4 flex justify-between items-center mb-3 sm:mb-4">
       <div class="flex items-center">
-        <div class="w-15 h-15 rounded-full overflow-hidden mr-3">
+        <div class="w-10 h-10 sm:w-12 sm:h-12 rounded-full overflow-hidden mr-2 flex-shrink-0">
           <% if @post.user.avatar.attached? %>
-            <%= image_tag @post.user.avatar.variant(resize_to_fill: [50, 50]), class: "w-full h-full object-cover" %>
+            <%= image_tag @post.user.avatar.variant(resize_to_fill: [48, 48]), class: "w-full h-full object-cover" %>
           <% else %>
             <%= image_tag "default_avatar.webp", class: "w-full h-full object-cover" %>
           <% end %>
         </div>
-        <div>
-          <p class="font-semibold"><%= @post.user.name %></p>
-          <p class="text-xs sm:text-sm text-subtleText"><%= @post.created_at.strftime("%Y/%m/%d %H:%M") %></p>
+        <div class="flex flex-col justify-center">
+          <p class="text-sm sm:text-[16px] font-semibold truncate max-w-[120px] sm:max-w-[200px]"><%= @post.user.name %></p>
+          <p class="text-xs sm:text-sm text-subtleText whitespace-nowrap pl-0.5"><%= @post.created_at.strftime("%Y/%m/%d %H:%M") %></p>
         </div>
       </div>
       <!-- 編集・削除ボタンまたはブックマーク -->
@@ -35,7 +35,7 @@
     </div>
 
     <!-- 店舗名 -->
-    <h1 class="text-3xl font-bold my-6 text-center"><%= @post.shop.name %></h1>
+    <h1 class="text-2xl md:text-3xl font-bold my-6 text-center"><%= @post.shop.name %></h1>
 
     <!-- 投稿画像 -->
     <div class="w-11/12 mx-auto aspect-square bg-gray-300 flex items-center justify-center rounded-lg mb-8 overflow-hidden">
@@ -60,24 +60,24 @@
     <div class="px-4 py-2 text-center font-bold my-6">
       <div class="flex justify-center items-center space-x-2 sm:space-x-4">
         <span class="sm:text-lg md:text-xl lg:text-2xl">
-          固さ: <%= t("enums.post.firmness.#{@post.firmness}") %>
+          甘さ: <%= t("enums.post.sweetness.#{@post.sweetness}") %>
         </span>
         <span class="sm:text-lg md:text-xl lg:text-2xl">|</span>
         <span class="sm:text-lg md:text-xl lg:text-2xl">
-          甘さ: <%= t("enums.post.sweetness.#{@post.sweetness}") %>
+          固さ: <%= t("enums.post.firmness.#{@post.firmness}") %>
         </span>
       </div>
     </div>
 
     <!-- コメント -->
     <div class="px-4 sm:px-6 md:px-8 lg:px-14 py-4">
-      <%= simple_format(@post.body, class: "text-sm sm:text-[16px] text-left break-words") %>
+      <%= simple_format(@post.body, class: "text-sm sm:text-lg text-left break-words") %>
     </div>
 
     <hr class="mt-6 mb-4 border-placeholder">
 
     <!-- 住所 -->
-    <div class="px-4 pb-4 text-sm sm:text-[16px] text-subtleText">
+    <div class="px-4 pb-4 text-sm sm:text-lg text-subtleText">
       <i class="fas fa-map-marker-alt mr-2 text-accent"></i><%= @post.shop&.address.present? ? @post.shop.address : t('posts.address_not_registered') %>
     </div>
   </div>

--- a/app/views/shared/_flash_messages.html.erb
+++ b/app/views/shared/_flash_messages.html.erb
@@ -1,7 +1,7 @@
 <% if flash.any? %>
   <div class="mx-auto px-2 sm:px-4 lg:px-6 mt-2">
     <% flash.each do |message_type, message| %>
-      <div class="<%= flash_background_color(message_type) %> px-4 py-2 rounded-md mb-4 shadow-md">
+      <div class="<%= flash_background_color(message_type) %> px-4 py-2 rounded-md shadow-md">
         <%= message %>
       </div>
     <% end %>


### PR DESCRIPTION
### 投稿一覧ページ

- ユーザー名が長すぎる場合省略して表示
- 甘さと固さの並びを検索フォームに合わせて修正
- ユーザー情報についてのレイアウトを調整

### 投稿詳細ページ

- ユーザー名が長すぎる場合省略して表示
- スマホ画面での店名の文字サイズを変更
- 甘さと固さの並びを検索フォームに合わせて修正
- ユーザー情報についてのレイアウトを調整
