### PR TITLE
本番環境のデフォルトURLオプション設定を追加

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -99,4 +99,6 @@ Rails.application.configure do
   # ]
   # Skip DNS rebinding protection for the default health check endpoint.
   # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
+  config.action_controller.default_url_options = { host: ENV['DEFAULT_HOST'] }
+  Rails.application.routes.default_url_options[:host] = ENV['DEFAULT_HOST']
 end


### PR DESCRIPTION
## 変更内容
production.rb ファイルに default_url_options の設定を追加しました。これにより、アプリケーション全体で一貫したホスト名を使用できるようになります。

## 変更理由
- OGP画像のURLなど、完全なURLが必要な場面で "Missing host to link to!" エラーが発生するのを防ぐため。
- 環境変数を使用することで、異なる環境（開発、ステージング、本番）で柔軟にホスト名を設定できるようにするため。

## 変更箇所
config/environments/production.rb に以下の設定を追加:

```ruby
config.action_controller.default_url_options = { host: ENV['DEFAULT_HOST'] }
Rails.application.routes.default_url_options[:host] = ENV['DEFAULT_HOST']
```

renderダッシュボードにDEFAULT_HOST 環境変数を設定済み

## 関連ISSUE
#169 