### PR TITLE
fix:XシェアURLにクエリパラメータを追加

### DIFF
--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -91,9 +91,13 @@
 
     <!-- Xシェア -->
     <div class="mt-2 sm:mt-4 text-center">
-      <% cache_key = "#{@post.id}-#{@post.updated_at.to_i}" %>
-      <% share_text = URI.encode_www_form_component("【プリン好き必見！】\n#{@post.shop.name}のプリンが美味しいらしい...\n#PurinMania") %>
-      <% twitter_share_url = "https://twitter.com/intent/tweet?text=#{share_text}&url=#{CGI.escape(post_url(@post, cache: cache_key))}" %>
+      <% 
+        base_url = post_url(@post)
+        timestamp = Time.now.to_i
+        share_url = "#{base_url}?t=#{timestamp}"
+        share_text = URI.encode_www_form_component("【プリン好き必見！】\n#{@post.shop.name}のプリンが美味しいらしい...\n#PurinMania")
+        twitter_share_url = "https://twitter.com/intent/tweet?text=#{share_text}&url=#{CGI.escape(share_url)}"
+      %>
       <%= link_to twitter_share_url, target: '_blank', rel: 'noopener noreferrer', class: "inline-block rounded-full" do %>
         <i class="fa-brands fa-square-x-twitter text-2xl sm:text-3xl text-accent"></i>
       <% end %>


### PR DESCRIPTION
## 変更内容
1. `show.html.erb`のTwitter共有機能を改善
2. OGP情報の取り扱いを最適化

## 変更理由
1. TwitterのOGPキャッシュ更新の問題に対処するため。
2. 共有されるURLの一意性を確保し、同じ投稿の複数回の共有を可能にするため。
4. OGP情報の更新をより確実に反映させるため。

## 主な変更点
1. `show.html.erb`のTwitter共有リンク生成ロジックを更新:
   - キャッシュキーの使用を廃止
   - 共有URLにタイムスタンプを追加
   - URLエンコーディングの適用

変更前:
```erb
<% cache_key = "#{@post.id}-#{@post.updated_at.to_i}" %>
<% share_text = URI.encode_www_form_component("【プリン好き必見！】\n#{@post.shop.name}のプリンが美味しいらしい...\n#PurinMania") %>
<% twitter_share_url = "https://twitter.com/intent/tweet?text=#{share_text}&url=#{CGI.escape(post_url(@post, cache: cache_key))}" %>
```

変更後:
```erb
<% 
  base_url = post_url(@post)
  timestamp = Time.now.to_i
  share_url = "#{base_url}?t=#{timestamp}"
  share_text = URI.encode_www_form_component("【プリン好き必見！】\n#{@post.shop.name}のプリンが美味しいらしい...\n#PurinMania")
  twitter_share_url = "https://twitter.com/intent/tweet?text=#{share_text}&url=#{CGI.escape(share_url)}"
%>
```

## 期待される効果
TwitterのOGPキャッシュが更新されやすくなり、最新の情報が表示されるようになること
同じ投稿を複数回共有しても、それぞれ異なるツイートとして認識されること

## 関連ISSUE
#169 