### PR TITLE
Add:ステータスバーの実装: 甘さと固さのパーセンテージ表示機能の追加

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -110,6 +110,6 @@ class PostsController < ApplicationController
   end
 
   def post_params
-    params.require(:post).permit(:body, :sweetness, :firmness, :overall_rating, :shop_name, :shop_address, :image)
+    params.require(:post).permit(:body, :sweetness_percentage, :firmness_percentage, :overall_rating, :shop_name, :shop_address, :image)
   end
 end

--- a/app/helpers/posts_helper.rb
+++ b/app/helpers/posts_helper.rb
@@ -24,30 +24,4 @@ module PostsHelper
       'bg-gray-400 text-textLight'
     end
   end
-
-  def sweetness_percentage(sweetness)
-    case sweetness
-    when 'mild'
-      15
-    when 'medium_sweet'
-      50
-    when 'sweet'
-      100
-    else
-      0
-    end
-  end
-
-  def firmness_percentage(firmness)
-    case firmness
-    when 'smooth'
-      15
-    when 'medium_firm'
-      50
-    when 'firm'
-      100
-    else
-      0
-    end
-  end
 end

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -12,3 +12,6 @@ application.register("tab", TabController)
 
 import SearchClearController from "./search_clear_controller"
 application.register("search-clear", SearchClearController)
+
+import StatusBarController from "./status_bar_controller"
+application.register("status-bar", StatusBarController)

--- a/app/javascript/controllers/status_bar_controller.js
+++ b/app/javascript/controllers/status_bar_controller.js
@@ -1,0 +1,33 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["range", "status"]
+
+  connect() {
+    this.updateAllStatuses()
+  }
+
+  updateStatus(event) {
+    const range = event.target
+    const statusElement = this.statusTargets.find(el => el.dataset.statusBarAttribute === range.dataset.attribute)
+    statusElement.textContent = this.getStatus(range.value, range.dataset.attribute)
+  }
+
+  updateAllStatuses() {
+    this.rangeTargets.forEach(range => {
+      const statusElement = this.statusTargets.find(el => el.dataset.statusBarAttribute === range.dataset.attribute)
+      statusElement.textContent = this.getStatus(range.value, range.dataset.attribute)
+    })
+  }
+
+  getStatus(value, attribute) {
+    const intValue = parseInt(value)
+    if (intValue <= 33) {
+      return attribute === 'sweetness' ? '控えめ' : 'なめらか'
+    } else if (intValue <= 66) {
+      return attribute === 'sweetness' ? 'ほどよい' : 'ほどよい'
+    } else {
+      return attribute === 'sweetness' ? '甘党向け' : 'かため'
+    }
+  }
+}

--- a/app/javascript/controllers/status_bar_controller.js
+++ b/app/javascript/controllers/status_bar_controller.js
@@ -1,33 +1,42 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-  static targets = ["range", "status"]
+  static targets = ["range", "statusText"]
 
   connect() {
-    this.updateAllStatuses()
+    this.rangeTargets.forEach(range => this.updateStatus({ target: range }))
   }
 
   updateStatus(event) {
     const range = event.target
-    const statusElement = this.statusTargets.find(el => el.dataset.statusBarAttribute === range.dataset.attribute)
-    statusElement.textContent = this.getStatus(range.value, range.dataset.attribute)
-  }
+    const value = parseInt(range.value)
+    const attribute = range.dataset.attribute
 
-  updateAllStatuses() {
-    this.rangeTargets.forEach(range => {
-      const statusElement = this.statusTargets.find(el => el.dataset.statusBarAttribute === range.dataset.attribute)
-      statusElement.textContent = this.getStatus(range.value, range.dataset.attribute)
+    this.statusTextTargets.forEach(statusText => {
+      if (statusText.dataset.attribute !== attribute) return
+
+      const status = statusText.dataset.status
+      let scale = 0.9
+      let opacity = 0.5
+
+      if ((status === 'mild' && value <= 33) ||
+          (status === 'smooth' && value <= 33) ||
+          (status === 'medium_sweet' && value > 33 && value <= 66) ||
+          (status === 'medium_firm' && value > 33 && value <= 66) ||
+          (status === 'sweet' && value > 66) ||
+          (status === 'firm' && value > 66)) {
+        scale = 1.1
+        opacity = 1
+      } else if ((status === 'mild' && value <= 66) ||
+                 (status === 'smooth' && value <= 66) ||
+                 (status === 'sweet' && value > 33) ||
+                 (status === 'firm' && value > 33)) {
+        scale = 0.9
+        opacity = 0.7
+      }
+
+      statusText.style.transform = `scale(${scale})`
+      statusText.style.opacity = opacity
     })
-  }
-
-  getStatus(value, attribute) {
-    const intValue = parseInt(value)
-    if (intValue <= 33) {
-      return attribute === 'sweetness' ? '控えめ' : 'なめらか'
-    } else if (intValue <= 66) {
-      return attribute === 'sweetness' ? 'ほどよい' : 'ほどよい'
-    } else {
-      return attribute === 'sweetness' ? '甘党向け' : 'かため'
-    }
   }
 }

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -8,12 +8,16 @@ class Post < ApplicationRecord
 
   accepts_nested_attributes_for :shop
 
+  attribute :sweetness_percentage, :integer, default: 50
+  attribute :firmness_percentage, :integer, default: 50
+
   validates :body, presence: true, length: { maximum: 555 }
   validates :sweetness, presence: true
   validates :firmness, presence: true
   validates :overall_rating, presence: true
+  validates :sweetness_percentage, :firmness_percentage, presence: true, inclusion: { in: 0..100 }
 
-  enum sweetness: { sweet: 0, medium_sweet: 1, mild: 2 }
+  enum sweetness: { mild: 0, medium_sweet: 1, sweet: 2 }
   enum firmness: { smooth: 0, medium_firm: 1, firm: 2 }
   enum overall_rating: {
   very_poor: 1,
@@ -22,6 +26,8 @@ class Post < ApplicationRecord
   good: 4,
   excellent: 5
   }
+
+  before_save :set_sweetness_and_firmness
 
   # 将来的に実装予定の機能のためのコメントアウト
   # belongs_to :category
@@ -34,4 +40,19 @@ class Post < ApplicationRecord
     ["user", "shop"]
   end
   
+  private
+
+  def set_sweetness_and_firmness
+    self.sweetness = case sweetness_percentage
+                     when 0..33 then 'mild'
+                     when 34..66 then 'medium_sweet'
+                     else 'sweet'
+                     end
+
+    self.firmness = case firmness_percentage
+                    when 0..33 then 'smooth'
+                    when 34..66 then 'medium_firm'
+                    else 'firm'
+                    end
+  end
 end

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -11,20 +11,28 @@
       <%= f.text_field :shop_address, placeholder: t('posts.form.shop_address_placeholder'), value: @post.shop_address || @post.shop&.address, class: "input input-bordered w-full bg-white text-sm sm:text-[16px] placeholder:text-sm placeholder:text-placeholder" %>
     </div>
 
-    <div class="mb-4">
-      <%= f.label :sweetness, class: "block text-neutral font-semibold mb-2" %>
-      <%= f.select :sweetness, 
-                   Post.sweetnesses.keys.map { |s| [t("enums.post.sweetness.#{s}"), s] }, 
-                   { prompt: t('defaults.select_prompt') }, 
-                   class: "select select-bordered w-full bg-white" %>
-    </div>
-
-    <div class="mb-4">
-      <%= f.label :firmness, class: "block text-neutral font-semibold mb-2" %>
-      <%= f.select :firmness, 
-                   Post.firmnesses.keys.map { |f| [t("enums.post.firmness.#{f}"), f] }, 
-                   { prompt: t('defaults.select_prompt') }, 
-                   class: "select select-bordered w-full bg-white" %>
+    <div data-controller="status-bar">
+      <div class="mb-4">
+        <%= f.label :sweetness_percentage, t('activerecord.attributes.post.sweetness'), class: "block text-neutral font-semibold mb-2" %>
+        <%= f.range_field :sweetness_percentage, in: 0..100, step: 1, class: "range", data: { action: "input->status-bar#updateStatus", status_bar_target: "range", attribute: "sweetness" } %>
+        <div class="w-full flex justify-between text-[10px] sm:text-xs px-2">
+          <div class="w-1/3 text-left"><%= t('enums.post.sweetness.mild') %></div>
+          <div class="w-1/3 text-center"><%= t('enums.post.sweetness.medium_sweet') %></div>
+          <div class="w-1/3 text-right"><%= t('enums.post.sweetness.sweet') %></div>
+        </div>
+        <p class="text-xs sm:text-sm my-2"><%= t('defaults.sweetness_confirm') %>: <span data-status-bar-target="status" data-status-bar-attribute="sweetness"></span></p>
+      </div>
+    
+      <div class="mb-4">
+        <%= f.label :firmness_percentage, t('activerecord.attributes.post.firmness'), class: "block text-neutral font-semibold mb-2" %>
+        <%= f.range_field :firmness_percentage, in: 0..100, step: 1, class: "range", data: { action: "input->status-bar#updateStatus", status_bar_target: "range", attribute: "firmness" } %>
+        <div class="w-full flex justify-between text-[10px] sm:text-xs px-2">
+          <div class="w-1/3 text-left"><%= t('enums.post.firmness.smooth') %></div>
+          <div class="w-1/3 text-center"><%= t('enums.post.firmness.medium_firm') %></div>
+          <div class="w-1/3 text-right"><%= t('enums.post.firmness.firm') %></div>
+        </div>
+        <p class="text-xs sm:text-sm my-2"><%= t('defaults.firmness_confirm') %>: <span data-status-bar-target="status" data-status-bar-attribute="firmness"></span></p>
+      </div>
     </div>
 
     <div class="mb-4">

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -15,23 +15,21 @@
       <div class="mb-4">
         <%= f.label :sweetness_percentage, t('activerecord.attributes.post.sweetness'), class: "block text-neutral font-semibold mb-2" %>
         <%= f.range_field :sweetness_percentage, in: 0..100, step: 1, class: "range", data: { action: "input->status-bar#updateStatus", status_bar_target: "range", attribute: "sweetness" } %>
-        <div class="w-full flex justify-between text-[10px] sm:text-xs px-2">
-          <div class="w-1/3 text-left"><%= t('enums.post.sweetness.mild') %></div>
-          <div class="w-1/3 text-center"><%= t('enums.post.sweetness.medium_sweet') %></div>
-          <div class="w-1/3 text-right"><%= t('enums.post.sweetness.sweet') %></div>
+        <div class="w-full flex text-xs sm:text-sm justify-between px-2 mt-2">
+          <div data-status-bar-target="statusText" data-status="mild" data-attribute="sweetness" class="w-1/3 text-center transition-all duration-300"><%= t('enums.post.sweetness.mild') %></div>
+          <div data-status-bar-target="statusText" data-status="medium_sweet" data-attribute="sweetness" class="w-1/3 text-center transition-all duration-300"><%= t('enums.post.sweetness.medium_sweet') %></div>
+          <div data-status-bar-target="statusText" data-status="sweet" data-attribute="sweetness" class="w-1/3 text-center transition-all duration-300"><%= t('enums.post.sweetness.sweet') %></div>
         </div>
-        <p class="text-xs sm:text-sm my-2"><%= t('defaults.sweetness_confirm') %>: <span data-status-bar-target="status" data-status-bar-attribute="sweetness"></span></p>
       </div>
     
       <div class="mb-4">
         <%= f.label :firmness_percentage, t('activerecord.attributes.post.firmness'), class: "block text-neutral font-semibold mb-2" %>
         <%= f.range_field :firmness_percentage, in: 0..100, step: 1, class: "range", data: { action: "input->status-bar#updateStatus", status_bar_target: "range", attribute: "firmness" } %>
-        <div class="w-full flex justify-between text-[10px] sm:text-xs px-2">
-          <div class="w-1/3 text-left"><%= t('enums.post.firmness.smooth') %></div>
-          <div class="w-1/3 text-center"><%= t('enums.post.firmness.medium_firm') %></div>
-          <div class="w-1/3 text-right"><%= t('enums.post.firmness.firm') %></div>
+        <div class="w-full flex text-xs sm:text-sm justify-between px-2 mt-2">
+          <div data-status-bar-target="statusText" data-status="smooth" data-attribute="firmness" class="w-1/3 text-center transition-all duration-300"><%= t('enums.post.firmness.smooth') %></div>
+          <div data-status-bar-target="statusText" data-status="medium_firm" data-attribute="firmness" class="w-1/3 text-center transition-all duration-300"><%= t('enums.post.firmness.medium_firm') %></div>
+          <div data-status-bar-target="statusText" data-status="firm" data-attribute="firmness" class="w-1/3 text-center transition-all duration-300"><%= t('enums.post.firmness.firm') %></div>
         </div>
-        <p class="text-xs sm:text-sm my-2"><%= t('defaults.firmness_confirm') %>: <span data-status-bar-target="status" data-status-bar-attribute="firmness"></span></p>
       </div>
     </div>
 

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -58,12 +58,12 @@
           <div class="flex flex-wrap justify-center sm:justify-start items-center mb-3 text-sm sm:text-[18px] text-center sm:text-left">
             <div class="flex items-center">
               <div class="tooltip" data-tip="<%= t("tooltips.sweetness.#{post.sweetness}") %>">
-                <span class="badge text-xs sm:text-sm py-2 sm:py-2.5 <%= sweetness_badge_color(post.sweetness) %> mr-0.5 sm:mr-1"><%= I18n.t("enums.post.sweetness.#{post.sweetness}") %></span>
+                <span class="badge text-xs sm:text-sm py-2 sm:py-2.5 <%= sweetness_badge_color(post.sweetness) %> mr-0.5 sm:mr-1"><%= t("enums.post.sweetness.#{post.sweetness}") %></span>
               </div>
             </div>
             <div class="flex items-center">
               <div class="tooltip" data-tip="<%= t("tooltips.firmness.#{post.firmness}") %>">
-                <span class="badge text-xs sm:text-sm py-2 sm:py-2.5 <%= firmness_badge_color(post.firmness) %>"><%= I18n.t("enums.post.firmness.#{post.firmness}") %></span>
+                <span class="badge text-xs sm:text-sm py-2 sm:py-2.5 <%= firmness_badge_color(post.firmness) %>"><%= t("enums.post.firmness.#{post.firmness}") %></span>
               </div>
             </div>
           </div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -87,9 +87,9 @@
           </div>
           <div class="relative">
             <div class="overflow-hidden h-2 mb-3 text-xs flex rounded bg-sweetLight">
-              <div style="width:<%= sweetness_percentage(@post.sweetness) %>%" class="shadow-none flex flex-col text-center whitespace-nowrap text-white justify-center bg-sweetDeep"></div>
+              <div style="width:<%= @post.sweetness_percentage %>%" class="shadow-none flex flex-col text-center whitespace-nowrap text-white justify-center bg-sweetDeep"></div>
             </div>
-            <div class="absolute top-1/2 -translate-y-1/2" style="left: calc(<%= sweetness_percentage(@post.sweetness) %>% - 8px);">
+            <div class="absolute top-1/2 -translate-y-1/2" style="left: calc(<%= @post.sweetness_percentage %>% - 8px);">
               <div class="w-4 h-4 bg-white rounded-full border-2 border-sweetDeep"></div>
             </div>
           </div>
@@ -105,9 +105,9 @@
           </div>
           <div class="relative">
             <div class="overflow-hidden h-2 mb-3 text-xs flex rounded bg-firmLight">
-              <div style="width:<%= firmness_percentage(@post.firmness) %>%" class="shadow-none flex flex-col text-center whitespace-nowrap text-white justify-center bg-firmDeep"></div>
+              <div style="width:<%= @post.firmness_percentage %>%" class="shadow-none flex flex-col text-center whitespace-nowrap text-white justify-center bg-firmDeep"></div>
             </div>
-            <div class="absolute top-1/2 -translate-y-1/2" style="left: calc(<%= firmness_percentage(@post.firmness) %>% - 8px);">
+            <div class="absolute top-1/2 -translate-y-1/2" style="left: calc(<%= @post.firmness_percentage %>% - 8px);">
               <div class="w-4 h-4 bg-white rounded-full border-2 border-firmDeep"></div>
             </div>
           </div>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -22,8 +22,6 @@ ja:
       updated: "%{item}を更新しました"
       not_updated: "%{item}を更新出来ませんでした"
       deleted: "%{item}を削除しました"
-    sweetness_confirm: "保存される甘さ"
-    firmness_confirm: "保存される固さ"
   static_pages:
     top:
       title: トップページ

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -22,6 +22,8 @@ ja:
       updated: "%{item}を更新しました"
       not_updated: "%{item}を更新出来ませんでした"
       deleted: "%{item}を削除しました"
+    sweetness_confirm: "保存される甘さ"
+    firmness_confirm: "保存される固さ"
   static_pages:
     top:
       title: トップページ

--- a/db/migrate/20241106105617_add_percentages_to_posts.rb
+++ b/db/migrate/20241106105617_add_percentages_to_posts.rb
@@ -1,0 +1,44 @@
+class AddPercentagesToPosts < ActiveRecord::Migration[7.2]
+  def up
+    add_column :posts, :sweetness_percentage, :integer
+    add_column :posts, :firmness_percentage, :integer
+
+    # 既存のデータを更新
+    Post.reset_column_information
+    Post.find_each do |post|
+      post.update_columns(
+        sweetness_percentage: convert_sweetness_to_percentage(post.sweetness),
+        firmness_percentage: convert_firmness_to_percentage(post.firmness)
+      )
+    end
+
+    # NULL制約を追加
+    change_column_null :posts, :sweetness_percentage, false
+    change_column_null :posts, :firmness_percentage, false
+  end
+
+  def down
+    remove_column :posts, :sweetness_percentage
+    remove_column :posts, :firmness_percentage
+  end
+
+  private
+
+  def convert_sweetness_to_percentage(sweetness)
+    case sweetness
+    when 'mild' then 25
+    when 'medium_sweet' then 50
+    when 'sweet' then 75
+    else 50 # デフォルト値
+    end
+  end
+
+  def convert_firmness_to_percentage(firmness)
+    case firmness
+    when 'smooth' then 25
+    when 'medium_firm' then 50
+    when 'firm' then 75
+    else 50 # デフォルト値
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_10_22_082846) do
+ActiveRecord::Schema[7.2].define(version: 2024_11_06_105617) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -61,6 +61,8 @@ ActiveRecord::Schema[7.2].define(version: 2024_10_22_082846) do
     t.integer "overall_rating", default: 1, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "sweetness_percentage", null: false
+    t.integer "firmness_percentage", null: false
     t.index ["firmness"], name: "index_posts_on_firmness"
     t.index ["overall_rating"], name: "index_posts_on_overall_rating"
     t.index ["shop_id", "user_id"], name: "index_posts_on_shop_id_and_user_id"


### PR DESCRIPTION
## 変更内容

投稿の甘さと固さをパーセンテージで表現するステータスバーの機能を追加
主な変更点：

1. `posts` テーブルに `sweetness_percentage` と `firmness_percentage` カラムを追加
2. 既存の投稿データを新しいパーセンテージ形式に変換
3. 投稿フォームにステータスバーを実装
4. 投稿詳細ページでのステータスバー表示を更新

## 動作確認項目

- [x] 新規投稿でステータスバーが正常に機能すること
- [x] 既存の投稿が正しくパーセンテージ形式に変換されていること
- [x] 投稿詳細ページでステータスバーが正しく表示されること

## 補足

既存のデータとの互換性も維持
投稿作成ページのステータスバーのデザインは今後修正予定

## 関連ISSUE
#182 
#178 