### PR TITLE
fix:レンジスライダーのデザイン変更

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -16,4 +16,44 @@
   .custom-file-input::file-selector-button:hover {
     @apply opacity-80;
   }
+
+  .custom-range-sweetness {
+    -webkit-appearance: none;
+    width: 100%;
+    height: 8px;
+    background: linear-gradient(to right, #C2566D 0%, #C2566D var(--value), #E6A8B8 var(--value) 100%);
+    border-radius: 5px;
+    outline: none;
+  }
+
+  .custom-range-sweetness::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    appearance: none;
+    width: 20px; /* Thumb width */
+    height: 20px; /* Thumb height */
+    border-radius: 50%;
+    background-color: #F5F5F5;
+    border: 4px solid #C2566D; /* Thumb border color */
+    cursor: pointer;
+  }
+
+  .custom-range-firmness {
+    -webkit-appearance: none;
+    width: 100%;
+    height: 8px;
+    background: linear-gradient(to right, #A67C5B 0%, #A67C5B var(--value), #D4B8A8 var(--value) 100%);
+    border-radius: 5px;
+    outline: none;
+  }
+
+  .custom-range-firmness::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    appearance: none;
+    width: 20px; /* Thumb width */
+    height: 20px; /* Thumb height */
+    border-radius: 50%;
+    background-color: #F5F5F5;
+    border: 4px solid #A67C5B; /* Thumb border color */
+    cursor: pointer;
+  }
 }

--- a/app/javascript/controllers/range_slider_controller.js
+++ b/app/javascript/controllers/range_slider_controller.js
@@ -12,6 +12,8 @@ export default class extends Controller {
     const value = parseInt(range.value)
     const attribute = range.dataset.attribute
 
+    range.style.setProperty('--value', value + '%')
+
     this.statusTextTargets.forEach(statusText => {
       if (statusText.dataset.attribute !== attribute) return
 

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -14,7 +14,7 @@
     <div data-controller="range-slider">
       <div class="mb-4">
         <%= f.label :sweetness_percentage, t('activerecord.attributes.post.sweetness'), class: "block text-neutral font-semibold mb-2" %>
-        <%= f.range_field :sweetness_percentage, in: 0..100, step: 1, class: "range", data: { action: "input->range-slider#updateStatus", range_slider_target: "range", attribute: "sweetness" } %>
+        <%= f.range_field :sweetness_percentage, in: 0..100, step: 1, class: "w-full custom-range-sweetness", data: { action: "input->range-slider#updateStatus", range_slider_target: "range", attribute: "sweetness" } %>
         <div class="w-full flex text-xs sm:text-sm justify-between px-2 mt-2">
           <div data-range-slider-target="statusText" data-status="mild" data-attribute="sweetness" class="w-1/3 text-center transition-all duration-300"><%= t('enums.post.sweetness.mild') %></div>
           <div data-range-slider-target="statusText" data-status="medium_sweet" data-attribute="sweetness" class="w-1/3 text-center transition-all duration-300"><%= t('enums.post.sweetness.medium_sweet') %></div>
@@ -24,7 +24,7 @@
     
       <div class="mb-4">
         <%= f.label :firmness_percentage, t('activerecord.attributes.post.firmness'), class: "block text-neutral font-semibold mb-2" %>
-        <%= f.range_field :firmness_percentage, in: 0..100, step: 1, class: "range", data: { action: "input->range-slider#updateStatus", range_slider_target: "range", attribute: "firmness" } %>
+        <%= f.range_field :firmness_percentage, in: 0..100, step: 1, class: "w-full custom-range-firmness", data: { action: "input->range-slider#updateStatus", range_slider_target: "range", attribute: "firmness" } %>
         <div class="w-full flex text-xs sm:text-sm justify-between px-2 mt-2">
           <div data-range-slider-target="statusText" data-status="smooth" data-attribute="firmness" class="w-1/3 text-center transition-all duration-300"><%= t('enums.post.firmness.smooth') %></div>
           <div data-range-slider-target="statusText" data-status="medium_firm" data-attribute="firmness" class="w-1/3 text-center transition-all duration-300"><%= t('enums.post.firmness.medium_firm') %></div>


### PR DESCRIPTION
## 変更内容
投稿作成ページのレンジスライダーを、daisyUIのrangeコンポーネントからHTMLの`<input type="range">`を使用したカスタムCSSに変更

## 関連ISSUE
- #185
- #182