### PR TITLE
Add:検索フォームに甘さと固さの並び替えを追加

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -33,7 +33,7 @@ class Post < ApplicationRecord
   # belongs_to :category
 
   def self.ransackable_attributes(auth_object = nil)
-    ["body", "sweetness", "firmness", "overall_rating", "created_at"]
+    ["body", "sweetness_percentage", "firmness_percentage", "sweetness", "firmness", "overall_rating", "created_at"]
   end
 
   def self.ransackable_associations(auth_object = nil)

--- a/app/views/posts/_search_form.html.erb
+++ b/app/views/posts/_search_form.html.erb
@@ -13,7 +13,7 @@
       <!-- 並び替え -->
       <div class="col-span-1 sm:col-span-1">
         <%= f.select :s,
-            [[t('.highest_rated'), 'overall_rating desc'], [t('.lowest_rated'), 'overall_rating asc'], [t('.newest_first'), 'created_at desc'], [t('.oldest_first'), 'created_at asc']],
+            [[t('.highest_rated'), 'overall_rating desc'], [t('.lowest_rated'), 'overall_rating asc'], [t('.sweetness_high'), 'sweetness_percentage desc'], [t('.sweetness_low'), 'sweetness_percentage asc'], [t('.firmness_high'), 'firmness_percentage desc'], [t('.firmness_low'), 'firmness_percentage asc'], [t('.newest_first'), 'created_at desc'], [t('.oldest_first'), 'created_at asc']],
             { include_blank: t('.sort') },
             class: 'select select-bordered w-full text-xs sm:text-sm bg-white',
             data: { search_clear_target: "select" } %>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -60,6 +60,10 @@ ja:
       lowest_rated: 評価が低い順
       newest_first: 新しい順
       oldest_first: 古い順
+      sweetness_high: 甘さが高い順
+      sweetness_low: 甘さが低い順
+      firmness_high: 固い順
+      firmness_low: 柔らかい順
   mypage:
     title: マイページ
     edit:


### PR DESCRIPTION
## 変更内容
_search_form.html.erbに甘さと固さの並び替えオプションを追加
国際化（i18n）のための翻訳キーを追加
Postモデルのransackable_attributesメソッドを更新

## 参考
- https://www.notion.so/ransack-1299ca21c80580f3aea6d8beac019caf?pvs=4

## 関連ISSUE
- #184