### PR TITLE
fix:投稿一覧のツールチップ文言を動的に表示

### DIFF
--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -57,12 +57,12 @@
           </div>
           <div class="flex flex-wrap justify-center sm:justify-start items-center mb-3 text-sm sm:text-[18px] text-center sm:text-left">
             <div class="flex items-center">
-              <div class="tooltip" data-tip="<%= t("tooltips.sweetness.#{post.sweetness}") %>">
+              <div class="tooltip" data-tip="<%= t("tooltips.sweetness", percentage: post.sweetness_percentage) %>">
                 <span class="badge text-xs sm:text-sm py-2 sm:py-2.5 <%= sweetness_badge_color(post.sweetness) %> mr-0.5 sm:mr-1"><%= t("enums.post.sweetness.#{post.sweetness}") %></span>
               </div>
             </div>
             <div class="flex items-center">
-              <div class="tooltip" data-tip="<%= t("tooltips.firmness.#{post.firmness}") %>">
+              <div class="tooltip" data-tip="<%= t("tooltips.firmness", percentage: post.firmness_percentage) %>">
                 <span class="badge text-xs sm:text-sm py-2 sm:py-2.5 <%= firmness_badge_color(post.firmness) %>"><%= t("enums.post.firmness.#{post.firmness}") %></span>
               </div>
             </div>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -79,12 +79,5 @@ ja:
         posts: 投稿したプリン
         bookmarks: 保存したプリン
   tooltips:
-    sweetness:
-      mild: 控えめな甘さです
-      medium_sweet: 程よい甘さです
-      sweet: 甘党向けの甘さです
-    firmness:
-      smooth: なめらかな食感です
-      medium_firm: 程よい固さです
-      firm: 固めの食感です
-
+    sweetness: "甘さ: %{percentage}"
+    firmness: "固さ: %{percentage}"


### PR DESCRIPTION
## 変更内容
投稿一覧ページの甘さと固さのバッジに表示されるツールチップの文言を修正。
パーセンテージの値のみを表示するようにし、より簡潔で直接的な情報提供を行うように実装。

## 変更詳細

1. `config/locales/ja.yml` の修正:
   - ツールチップの文言をシンプル化し、パーセンテージの値のみを表示するように変更。

2. `app/views/posts/_post.html.erb` の修正:
   - ツールチップのデータ属性を更新し、新しい翻訳キーとパーセンテージの値を使用するように変更。

## 動作確認
 - [x] 投稿一覧ページで甘さのバッジにマウスオーバーした際に、"甘さ: [数値]" の形式でツールチップが表示されることを確認
 - [x] 投稿一覧ページで固さのバッジにマウスオーバーした際に、"固さ: [数値]" の形式でツールチップが表示されることを確認
 - [x] 表示される数値が整数であることを確認（小数点以下が切り捨てられていること）
 - [x] 異なる甘さ・固さの値を持つ複数の投稿で正しく表示されることを確認

## 関連ISSUE
- #191 