### PR TITLE
Fix/プレビュー画像と住所出し分けの変更とレイアウトの調整

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -6,7 +6,7 @@
 
 @layer components {
   .custom-file-input {
-    @apply file-input-bordered form-control w-full mx-auto text-placeholder bg-white;
+    @apply file-input-bordered form-control w-full mx-auto text-placeholder bg-white text-sm sm:text-[16px];
   }
 
   .custom-file-input::file-selector-button {

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,19 +1,19 @@
 <% content_for(:title, t('.title')) %>
 <div class="flex flex-col justify-between items-center h-full mt-8">
   <div class="w-full max-w-md">
-    <h2 class="text-neutral text-xl sm:text-2xl font-bold text-center my-4 sm:my-8"><%= t('.title', resource: resource.model_name.human) %></h2>
+    <h2 class="text-xl sm:text-2xl font-bold text-center my-4 sm:my-8"><%= t('.title', resource: resource.model_name.human) %></h2>
     
     <div class="px-10 sm:px-6 py-6">
       <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
         <%= render "devise/shared/error_messages", resource: resource %>
 
         <div class="mb-8 sm:mb-10 text-sm sm:text-[16px]">
-          <%= f.label :name, class: "block text-neutral font-semibold mb-2 sm:mb-4" %>
+          <%= f.label :name, class: "block font-semibold mb-2 sm:mb-4" %>
           <%= f.text_field :name, class: "input input-bordered w-full bg-white" %>
         </div>
 
         <div class="mb-8 sm:mb-10 text-sm sm:text-[16px]">
-          <%= f.label :avatar, class: "block text-neutral font-semibold mb-2 sm:mb-4" %>
+          <%= f.label :avatar, class: "block font-semibold mb-2 sm:mb-4" %>
           <%= f.file_field :avatar, accept: 'image/*', class: "file-input custom-file-input" %>
         </div>
 

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,28 +1,28 @@
 <% content_for(:title, t('.title')) %>
 <div class="flex flex-col justify-between items-center h-full mt-8">
   <div class="w-full max-w-md">
-    <h2 class="text-neutral text-2xl font-bold text-center mb-6"><%= t('.title', resource: resource.model_name.human) %></h2>
+    <h2 class="text-neutral text-xl sm:text-2xl font-bold text-center my-4 sm:my-8"><%= t('.title', resource: resource.model_name.human) %></h2>
     
-    <div class="bg-base-100 p-6">
+    <div class="px-10 sm:px-6 py-6">
       <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
         <%= render "devise/shared/error_messages", resource: resource %>
 
-        <div class="mb-4">
-          <%= f.label :name, class: "block text-neutral font-semibold mb-2" %>
+        <div class="mb-8 sm:mb-10 text-sm sm:text-[16px]">
+          <%= f.label :name, class: "block text-neutral font-semibold mb-2 sm:mb-4" %>
           <%= f.text_field :name, class: "input input-bordered w-full bg-white" %>
         </div>
 
-        <div class="mb-4">
-          <%= f.label :avatar, class: "block text-neutral font-semibold mb-2" %>
+        <div class="mb-8 sm:mb-10 text-sm sm:text-[16px]">
+          <%= f.label :avatar, class: "block text-neutral font-semibold mb-2 sm:mb-4" %>
           <%= f.file_field :avatar, accept: 'image/*', class: "file-input custom-file-input" %>
         </div>
 
-        <div class="text-center mt-8">
+        <div class="text-center mt-12 sm:mt-16">
           <%= f.submit t('.update'), class: "btn btn-primary text-white w-20" %>
         </div>
       <% end %>
 
-      <div class="text-center mt-4">
+      <div class="text-center mt-4 sm:mt-6 text-sm sm:text-[16px]">
         <%= link_to t('devise.shared.links.back'), :back, class: "text-accent hover:underline" %>
       </div>
     </div>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -17,14 +17,6 @@
           <%= f.file_field :avatar, accept: 'image/*', class: "file-input custom-file-input" %>
         </div>
 
-        <% if resource.avatar.attached? %>
-          <div class="mt-8 mb-4 flex justify-center">
-            <div class="w-24 h-24 overflow-hidden rounded-full">
-              <%= image_tag resource.avatar.variant(resize_to_fill: [100, 100]), class: "w-full h-full object-cover" %>
-            </div>
-          </div>
-        <% end %>
-
         <div class="text-center mt-8">
           <%= f.submit t('.update'), class: "btn btn-primary text-white w-20" %>
         </div>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -3,36 +3,36 @@
   <div class="w-full max-w-md">
     <h2 class="text-neutral text-xl sm:text-2xl font-bold text-center my-4 sm:my-8"><%= t('.title') %></h2>
     
-    <div class="px-12 sm:px-6 py-6 bg-base-100">
+    <div class="px-10 sm:px-6 py-6">
       <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %> 
         <%= render 'shared/error_messages', object: f.object %>
         
         <div class="mb-8 sm:mb-10 text-sm sm:text-[16px]">
-          <%= f.label :name, class: "block text-neutral font-semibold mb-2" %>
+          <%= f.label :name, class: "block text-neutral font-semibold mb-2 sm:mb-4" %>
           <%= f.text_field :name, autofocus: true, class: "input input-bordered w-full bg-white" %>
         </div>
         
         <div class="mb-8 sm:mb-10 text-sm sm:text-[16px]">
-          <%= f.label :email, class: "block text-neutral font-semibold mb-2" %>
+          <%= f.label :email, class: "block text-neutral font-semibold mb-2 sm:mb-4" %>
           <%= f.email_field :email, class: "input input-bordered w-full bg-white", autocomplete: "email" %>
         </div>
 
         <div class="mb-8 sm:mb-10 text-sm sm:text-[16px]">
-          <%= f.label :password, class: "block text-neutral font-semibold mb-2" %>
+          <%= f.label :password, class: "block text-neutral font-semibold mb-2 sm:mb-4" %>
           <%= f.password_field :password, class: "input input-bordered w-full bg-white", autocomplete: "new-password" %>
         </div>
 
         <div class="mb-8 sm:mb-10 text-sm sm:text-[16px]">
-          <%= f.label :password_confirmation, class: "block text-neutral font-semibold mb-2" %>
+          <%= f.label :password_confirmation, class: "block text-neutral font-semibold mb-2 sm:mb-4" %>
           <%= f.password_field :password_confirmation, class: "input input-bordered w-full bg-white", autocomplete: "new-password" %>
         </div>
 
-        <div class="text-center">
+        <div class="text-center mt-8 sm:mt-12">
           <%= f.submit t('.button'), class: "btn btn-primary text-white w-20" %>
         </div>
       <% end %>
 
-      <div class="text-center mt-4 sm:mt-6 text-sm sm:text-[16px]">
+      <div class="text-center mt-4 sm:mt-6 mb-12 sm:mb-16 text-sm sm:text-[16px]">
         <%= t('devise.shared.links.already_have_account') %><!--
         --><%= link_to t('devise.shared.links.here'), new_session_path(resource_name), class: "text-accent hover:underline" %>
       </div>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -7,22 +7,22 @@
       <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %> 
         <%= render 'shared/error_messages', object: f.object %>
         
-        <div class="mb-6 sm:mb-8 text-sm sm:text-[16px]">
+        <div class="mb-8 sm:mb-10 text-sm sm:text-[16px]">
           <%= f.label :name, class: "block text-neutral font-semibold mb-2" %>
           <%= f.text_field :name, autofocus: true, class: "input input-bordered w-full bg-white" %>
         </div>
         
-        <div class="mb-6 sm:mb-8 text-sm sm:text-[16px]">
+        <div class="mb-8 sm:mb-10 text-sm sm:text-[16px]">
           <%= f.label :email, class: "block text-neutral font-semibold mb-2" %>
           <%= f.email_field :email, class: "input input-bordered w-full bg-white", autocomplete: "email" %>
         </div>
 
-        <div class="mb-6 sm:mb-8 text-sm sm:text-[16px]">
+        <div class="mb-8 sm:mb-10 text-sm sm:text-[16px]">
           <%= f.label :password, class: "block text-neutral font-semibold mb-2" %>
           <%= f.password_field :password, class: "input input-bordered w-full bg-white", autocomplete: "new-password" %>
         </div>
 
-        <div class="mb-6 sm:mb-8 text-sm sm:text-[16px]">
+        <div class="mb-8 sm:mb-10 text-sm sm:text-[16px]">
           <%= f.label :password_confirmation, class: "block text-neutral font-semibold mb-2" %>
           <%= f.password_field :password_confirmation, class: "input input-bordered w-full bg-white", autocomplete: "new-password" %>
         </div>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,28 +1,28 @@
 <% content_for(:title, t('.title')) %>
 <div class="flex flex-col justify-between items-center h-full mt-8">
   <div class="w-full max-w-md">
-    <h2 class="text-neutral text-2xl font-bold text-center mb-6"><%= t('.title') %></h2>
+    <h2 class="text-neutral text-xl sm:text-2xl font-bold text-center my-4 sm:my-8"><%= t('.title') %></h2>
     
-    <div class="bg-base-100 p-6">
+    <div class="px-12 sm:px-6 py-6 bg-base-100">
       <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %> 
         <%= render 'shared/error_messages', object: f.object %>
         
-        <div class="mb-4">
+        <div class="mb-6 sm:mb-8 text-sm sm:text-[16px]">
           <%= f.label :name, class: "block text-neutral font-semibold mb-2" %>
           <%= f.text_field :name, autofocus: true, class: "input input-bordered w-full bg-white" %>
         </div>
         
-        <div class="mb-4">
+        <div class="mb-6 sm:mb-8 text-sm sm:text-[16px]">
           <%= f.label :email, class: "block text-neutral font-semibold mb-2" %>
           <%= f.email_field :email, class: "input input-bordered w-full bg-white", autocomplete: "email" %>
         </div>
 
-        <div class="mb-4">
+        <div class="mb-6 sm:mb-8 text-sm sm:text-[16px]">
           <%= f.label :password, class: "block text-neutral font-semibold mb-2" %>
           <%= f.password_field :password, class: "input input-bordered w-full bg-white", autocomplete: "new-password" %>
         </div>
 
-        <div class="mb-6">
+        <div class="mb-6 sm:mb-8 text-sm sm:text-[16px]">
           <%= f.label :password_confirmation, class: "block text-neutral font-semibold mb-2" %>
           <%= f.password_field :password_confirmation, class: "input input-bordered w-full bg-white", autocomplete: "new-password" %>
         </div>
@@ -32,7 +32,7 @@
         </div>
       <% end %>
 
-      <div class="text-center mt-4">
+      <div class="text-center mt-4 sm:mt-6 text-sm sm:text-[16px]">
         <%= t('devise.shared.links.already_have_account') %><!--
         --><%= link_to t('devise.shared.links.here'), new_session_path(resource_name), class: "text-accent hover:underline" %>
       </div>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,29 +1,29 @@
 <% content_for(:title, t('.title')) %>
 <div class="flex flex-col justify-between items-center h-full mt-8">
   <div class="w-full max-w-md">
-    <h2 class="text-neutral text-xl sm:text-2xl font-bold text-center my-4 sm:my-8"><%= t('.title') %></h2>
+    <h2 class="text-xl sm:text-2xl font-bold text-center my-4 sm:my-8"><%= t('.title') %></h2>
     
     <div class="px-10 sm:px-6 py-6">
       <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %> 
         <%= render 'shared/error_messages', object: f.object %>
         
         <div class="mb-8 sm:mb-10 text-sm sm:text-[16px]">
-          <%= f.label :name, class: "block text-neutral font-semibold mb-2 sm:mb-4" %>
+          <%= f.label :name, class: "block font-semibold mb-2 sm:mb-4" %>
           <%= f.text_field :name, autofocus: true, class: "input input-bordered w-full bg-white" %>
         </div>
         
         <div class="mb-8 sm:mb-10 text-sm sm:text-[16px]">
-          <%= f.label :email, class: "block text-neutral font-semibold mb-2 sm:mb-4" %>
+          <%= f.label :email, class: "block font-semibold mb-2 sm:mb-4" %>
           <%= f.email_field :email, class: "input input-bordered w-full bg-white", autocomplete: "email" %>
         </div>
 
         <div class="mb-8 sm:mb-10 text-sm sm:text-[16px]">
-          <%= f.label :password, class: "block text-neutral font-semibold mb-2 sm:mb-4" %>
+          <%= f.label :password, class: "block font-semibold mb-2 sm:mb-4" %>
           <%= f.password_field :password, class: "input input-bordered w-full bg-white", autocomplete: "new-password" %>
         </div>
 
         <div class="mb-8 sm:mb-10 text-sm sm:text-[16px]">
-          <%= f.label :password_confirmation, class: "block text-neutral font-semibold mb-2 sm:mb-4" %>
+          <%= f.label :password_confirmation, class: "block font-semibold mb-2 sm:mb-4" %>
           <%= f.password_field :password_confirmation, class: "input input-bordered w-full bg-white", autocomplete: "new-password" %>
         </div>
 

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -7,7 +7,7 @@
       <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %> 
         <%= render 'shared/error_messages', object: f.object %>
 
-        <div class="mb-6 sm:mb-8 text-sm sm:text-[16px]">
+        <div class="mb-8 sm:mb-10 text-sm sm:text-[16px]">
           <%= f.label :email, class: "block font-semibold mb-2" %>
           <%= f.email_field :email, autofocus: true, class: "input input-bordered w-full bg-white", autocomplete: "email" %>
         </div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -3,17 +3,17 @@
   <div class="w-full max-w-md">
     <h2 class="text-xl sm:text-2xl font-bold text-center my-4 sm:my-8"><%= t('.title') %></h2>
     
-    <div class="px-12 sm:px-6 py-6 ">
+    <div class="px-10 sm:px-6 py-6">
       <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %> 
         <%= render 'shared/error_messages', object: f.object %>
 
         <div class="mb-8 sm:mb-10 text-sm sm:text-[16px]">
-          <%= f.label :email, class: "block font-semibold mb-2" %>
+          <%= f.label :email, class: "block font-semibold mb-2 sm:mb-4" %>
           <%= f.email_field :email, autofocus: true, class: "input input-bordered w-full bg-white", autocomplete: "email" %>
         </div>
         
         <div class="mb-2 sm:mb-4 text-sm sm:text-[16px]">
-          <%= f.label :password, class: "block font-semibold mb-2" %>
+          <%= f.label :password, class: "block font-semibold mb-2 sm:mb-4" %>
           <%= f.password_field :password, class: "input input-bordered w-full bg-white", autocomplete: "current-password" %>
         </div>
 

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,35 +1,35 @@
 <% content_for(:title, t('.title')) %>
 <div class="flex flex-col justify-between items-center h-full mt-8">
   <div class="w-full max-w-md">
-    <h2 class="text-neutral text-2xl font-bold text-center mb-6"><%= t('.title') %></h2>
+    <h2 class="text-xl sm:text-2xl font-bold text-center my-4 sm:my-8"><%= t('.title') %></h2>
     
-    <div class="bg-base-100 p-6">
+    <div class="px-12 sm:px-6 py-6 ">
       <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %> 
         <%= render 'shared/error_messages', object: f.object %>
 
-        <div class="mb-4">
-          <%= f.label :email, class: "block text-neutral font-semibold mb-2" %>
+        <div class="mb-6 sm:mb-8 text-sm sm:text-[16px]">
+          <%= f.label :email, class: "block font-semibold mb-2" %>
           <%= f.email_field :email, autofocus: true, class: "input input-bordered w-full bg-white", autocomplete: "email" %>
         </div>
         
-        <div class="mb-6">
-          <%= f.label :password, class: "block text-neutral font-semibold mb-2" %>
+        <div class="mb-2 sm:mb-4 text-sm sm:text-[16px]">
+          <%= f.label :password, class: "block font-semibold mb-2" %>
           <%= f.password_field :password, class: "input input-bordered w-full bg-white", autocomplete: "current-password" %>
         </div>
 
         <% if devise_mapping.rememberable? %>
-          <div class="flex items-center mb-4">
-          <%= f.check_box :remember_me, class: "checkbox checkbox-accent bg-white checkbox-sm" %>
-            <%= f.label :remember_me, class: "ml-2 text-neutral" %>
+          <div class="flex items-center mb-10 sm:mb-12">
+            <%= f.check_box :remember_me, class: "checkbox checkbox-accent ml-1 bg-white checkbox-xs sm:checkbox-sm" %>
+            <%= f.label :remember_me, class: "ml-2 text-sm sm:text-[16px]" %>
           </div>
         <% end %>
 
         <div class="text-center">
-          <%= f.submit "ログイン", class: "btn btn-primary text-white" %>
+          <%= f.submit t('.button'), class: "btn btn-primary text-white" %>
         </div>
       <% end %>
 
-      <div class="text-center mt-4">
+      <div class="text-center mt-4 sm:mt-6 text-sm sm:text-[16px]">
         <%= t('devise.shared.links.sign_up_prompt') %><!--
         --><%= link_to t('devise.shared.links.here'), new_registration_path(resource_name), class: "text-accent hover:underline" %><br>
         <%= t('devise.shared.links.forgot_password_prompt') %><!--

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -2,18 +2,18 @@
   <%= form_with(model: post, local: true) do |f| %>
     <%= render 'shared/error_messages', object: f.object %>
     <div class="mb-8 sm:mb-10 text-sm sm:text-[16px]">
-      <%= f.label :shop_name, t('activerecord.attributes.shop.name'), class: "block text-neutral font-semibold mb-4" %>
+      <%= f.label :shop_name, t('activerecord.attributes.shop.name'), class: "block text-neutral font-semibold mb-2 sm:mb-4" %>
       <%= f.text_field :shop_name, placeholder: t('posts.form.shop_name_placeholder'), value: @post.shop_name || @post.shop&.name, class: "input input-bordered w-full bg-white text-sm sm:text-[16px] placeholder:text-sm placeholder:text-placeholder" %>
     </div>
     
     <div class="mb-8 sm:mb-10 text-sm sm:text-[16px]">
-      <%= f.label :shop_address, t('activerecord.attributes.shop.address'), class: "block text-neutral font-semibold mb-4" %>
+      <%= f.label :shop_address, t('activerecord.attributes.shop.address'), class: "block text-neutral font-semibold mb-2 sm:mb-4" %>
       <%= f.text_field :shop_address, placeholder: t('posts.form.shop_address_placeholder'), value: @post.shop_address || @post.shop&.address, class: "input input-bordered w-full bg-white text-sm sm:text-[16px] placeholder:text-sm placeholder:text-placeholder" %>
     </div>
 
     <div data-controller="range-slider">
       <div class="mb-8 sm:mb-10 text-sm sm:text-[16px]">
-        <%= f.label :sweetness_percentage, t('activerecord.attributes.post.sweetness'), class: "block text-neutral font-semibold mb-4" %>
+        <%= f.label :sweetness_percentage, t('activerecord.attributes.post.sweetness'), class: "block text-neutral font-semibold mb-4 sm:mb-6" %>
         <%= f.range_field :sweetness_percentage, in: 0..100, step: 1, class: "w-full custom-range-sweetness", data: { action: "input->range-slider#updateStatus", range_slider_target: "range", attribute: "sweetness" } %>
         <div class="w-full flex text-xs sm:text-sm justify-between px-2 mt-2">
           <div data-range-slider-target="statusText" data-status="mild" data-attribute="sweetness" class="w-1/3 text-center transition-all duration-300"><%= t('enums.post.sweetness.mild') %></div>
@@ -23,7 +23,7 @@
       </div>
     
       <div class="mb-8 sm:mb-10 text-sm sm:text-[16px]">
-        <%= f.label :firmness_percentage, t('activerecord.attributes.post.firmness'), class: "block text-neutral font-semibold mb-4" %>
+        <%= f.label :firmness_percentage, t('activerecord.attributes.post.firmness'), class: "block text-neutral font-semibold mb-4 sm:mb-6" %>
         <%= f.range_field :firmness_percentage, in: 0..100, step: 1, class: "w-full custom-range-firmness", data: { action: "input->range-slider#updateStatus", range_slider_target: "range", attribute: "firmness" } %>
         <div class="w-full flex text-xs sm:text-sm justify-between px-2 mt-2">
           <div data-range-slider-target="statusText" data-status="smooth" data-attribute="firmness" class="w-1/3 text-center transition-all duration-300"><%= t('enums.post.firmness.smooth') %></div>
@@ -34,7 +34,7 @@
     </div>
 
     <div class="mb-8 sm:mb-10 text-sm sm:text-[16px]">
-      <%= f.label :overall_rating, class: "block text-neutral font-semibold mb-4" %>
+      <%= f.label :overall_rating, class: "block text-neutral font-semibold mb-4 sm:mb-6" %>
       <div class="rating rating-lg flex justify-center space-x-2">
         <% Post.overall_ratings.each do |key, value| %>
           <%= f.radio_button :overall_rating, key, class: "mask mask-star-2 bg-accent" %>
@@ -43,12 +43,12 @@
     </div>
 
     <div class="mb-8 sm:mb-10 text-sm sm:text-[16px]">
-      <%= f.label :image, class: "block text-neutral font-semibold mb-4" %>
+      <%= f.label :image, class: "block text-neutral font-semibold mb-2 sm:mb-4" %>
       <%= f.file_field :image, accept: 'image/*', class: "file-input custom-file-input" %>
     </div>
 
     <div class="mb-8 sm:mb-10 text-sm sm:text-[16px]">
-      <%= f.label :body, class: "block text-neutral font-semibold mb-4" %>
+      <%= f.label :body, class: "block text-neutral font-semibold mb-2 sm:mb-4" %>
       <%= f.text_area :body, placeholder: t('posts.form.body_placeholder'), class: "textarea textarea-bordered w-full bg-white placeholder-placeholder text-sm placeholder:text-placeholder", rows: 4 %>
     </div>
 

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -47,12 +47,6 @@
       <%= f.file_field :image, accept: 'image/*', class: "file-input custom-file-input" %>
     </div>
 
-    <% if post.image.attached? %>
-      <div class="mb-4 flex justify-center">
-        <%= image_tag post.image.variant(resize_to_limit: [300, 300]), class: "rounded-lg object-cover w-64 h-64" %>
-      </div>
-    <% end %>
-
     <div class="mb-6">
       <%= f.label :body, class: "block text-neutral font-semibold mb-2" %>
       <%= f.text_area :body, placeholder: t('posts.form.body_placeholder'), class: "textarea textarea-bordered w-full bg-white placeholder-placeholder text-sm placeholder:text-placeholder", rows: 4 %>

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -1,19 +1,19 @@
-<div class="bg-base-100 p-6 rounded-md">
+<div class="p-6">
   <%= form_with(model: post, local: true) do |f| %>
     <%= render 'shared/error_messages', object: f.object %>
-    <div class="mb-4">
-      <%= f.label :shop_name, t('activerecord.attributes.shop.name'), class: "block text-neutral font-semibold mb-2" %>
+    <div class="mb-8 sm:mb-10 text-sm sm:text-[16px]">
+      <%= f.label :shop_name, t('activerecord.attributes.shop.name'), class: "block text-neutral font-semibold mb-4" %>
       <%= f.text_field :shop_name, placeholder: t('posts.form.shop_name_placeholder'), value: @post.shop_name || @post.shop&.name, class: "input input-bordered w-full bg-white text-sm sm:text-[16px] placeholder:text-sm placeholder:text-placeholder" %>
     </div>
     
-    <div class="mb-4">
-      <%= f.label :shop_address, t('activerecord.attributes.shop.address'), class: "block text-neutral font-semibold mb-2" %>
+    <div class="mb-8 sm:mb-10 text-sm sm:text-[16px]">
+      <%= f.label :shop_address, t('activerecord.attributes.shop.address'), class: "block text-neutral font-semibold mb-4" %>
       <%= f.text_field :shop_address, placeholder: t('posts.form.shop_address_placeholder'), value: @post.shop_address || @post.shop&.address, class: "input input-bordered w-full bg-white text-sm sm:text-[16px] placeholder:text-sm placeholder:text-placeholder" %>
     </div>
 
     <div data-controller="range-slider">
-      <div class="mb-4">
-        <%= f.label :sweetness_percentage, t('activerecord.attributes.post.sweetness'), class: "block text-neutral font-semibold mb-2" %>
+      <div class="mb-8 sm:mb-10 text-sm sm:text-[16px]">
+        <%= f.label :sweetness_percentage, t('activerecord.attributes.post.sweetness'), class: "block text-neutral font-semibold mb-4" %>
         <%= f.range_field :sweetness_percentage, in: 0..100, step: 1, class: "w-full custom-range-sweetness", data: { action: "input->range-slider#updateStatus", range_slider_target: "range", attribute: "sweetness" } %>
         <div class="w-full flex text-xs sm:text-sm justify-between px-2 mt-2">
           <div data-range-slider-target="statusText" data-status="mild" data-attribute="sweetness" class="w-1/3 text-center transition-all duration-300"><%= t('enums.post.sweetness.mild') %></div>
@@ -22,8 +22,8 @@
         </div>
       </div>
     
-      <div class="mb-4">
-        <%= f.label :firmness_percentage, t('activerecord.attributes.post.firmness'), class: "block text-neutral font-semibold mb-2" %>
+      <div class="mb-8 sm:mb-10 text-sm sm:text-[16px]">
+        <%= f.label :firmness_percentage, t('activerecord.attributes.post.firmness'), class: "block text-neutral font-semibold mb-4" %>
         <%= f.range_field :firmness_percentage, in: 0..100, step: 1, class: "w-full custom-range-firmness", data: { action: "input->range-slider#updateStatus", range_slider_target: "range", attribute: "firmness" } %>
         <div class="w-full flex text-xs sm:text-sm justify-between px-2 mt-2">
           <div data-range-slider-target="statusText" data-status="smooth" data-attribute="firmness" class="w-1/3 text-center transition-all duration-300"><%= t('enums.post.firmness.smooth') %></div>
@@ -33,8 +33,8 @@
       </div>
     </div>
 
-    <div class="mb-4">
-      <%= f.label :overall_rating, class: "block text-neutral font-semibold mb-2" %>
+    <div class="mb-8 sm:mb-10 text-sm sm:text-[16px]">
+      <%= f.label :overall_rating, class: "block text-neutral font-semibold mb-4" %>
       <div class="rating rating-lg flex justify-center space-x-2">
         <% Post.overall_ratings.each do |key, value| %>
           <%= f.radio_button :overall_rating, key, class: "mask mask-star-2 bg-accent" %>
@@ -42,13 +42,13 @@
       </div>
     </div>
 
-    <div class="mb-4">
-      <%= f.label :image, class: "block text-neutral font-semibold mb-2" %>
+    <div class="mb-8 sm:mb-10 text-sm sm:text-[16px]">
+      <%= f.label :image, class: "block text-neutral font-semibold mb-4" %>
       <%= f.file_field :image, accept: 'image/*', class: "file-input custom-file-input" %>
     </div>
 
-    <div class="mb-6">
-      <%= f.label :body, class: "block text-neutral font-semibold mb-2" %>
+    <div class="mb-8 sm:mb-10 text-sm sm:text-[16px]">
+      <%= f.label :body, class: "block text-neutral font-semibold mb-4" %>
       <%= f.text_area :body, placeholder: t('posts.form.body_placeholder'), class: "textarea textarea-bordered w-full bg-white placeholder-placeholder text-sm placeholder:text-placeholder", rows: 4 %>
     </div>
 

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -2,18 +2,18 @@
   <%= form_with(model: post, local: true) do |f| %>
     <%= render 'shared/error_messages', object: f.object %>
     <div class="mb-8 sm:mb-10 text-sm sm:text-[16px]">
-      <%= f.label :shop_name, t('activerecord.attributes.shop.name'), class: "block text-neutral font-semibold mb-2 sm:mb-4" %>
+      <%= f.label :shop_name, t('activerecord.attributes.shop.name'), class: "block font-semibold mb-2 sm:mb-4" %>
       <%= f.text_field :shop_name, placeholder: t('posts.form.shop_name_placeholder'), value: @post.shop_name || @post.shop&.name, class: "input input-bordered w-full bg-white text-sm sm:text-[16px] placeholder:text-sm placeholder:text-placeholder" %>
     </div>
     
     <div class="mb-8 sm:mb-10 text-sm sm:text-[16px]">
-      <%= f.label :shop_address, t('activerecord.attributes.shop.address'), class: "block text-neutral font-semibold mb-2 sm:mb-4" %>
+      <%= f.label :shop_address, t('activerecord.attributes.shop.address'), class: "block font-semibold mb-2 sm:mb-4" %>
       <%= f.text_field :shop_address, placeholder: t('posts.form.shop_address_placeholder'), value: @post.shop_address || @post.shop&.address, class: "input input-bordered w-full bg-white text-sm sm:text-[16px] placeholder:text-sm placeholder:text-placeholder" %>
     </div>
 
     <div data-controller="range-slider">
       <div class="mb-8 sm:mb-10 text-sm sm:text-[16px]">
-        <%= f.label :sweetness_percentage, t('activerecord.attributes.post.sweetness'), class: "block text-neutral font-semibold mb-4 sm:mb-6" %>
+        <%= f.label :sweetness_percentage, t('activerecord.attributes.post.sweetness'), class: "block font-semibold mb-4 sm:mb-6" %>
         <%= f.range_field :sweetness_percentage, in: 0..100, step: 1, class: "w-full custom-range-sweetness", data: { action: "input->range-slider#updateStatus", range_slider_target: "range", attribute: "sweetness" } %>
         <div class="w-full flex text-xs sm:text-sm justify-between px-2 mt-2">
           <div data-range-slider-target="statusText" data-status="mild" data-attribute="sweetness" class="w-1/3 text-center transition-all duration-300"><%= t('enums.post.sweetness.mild') %></div>
@@ -23,7 +23,7 @@
       </div>
     
       <div class="mb-8 sm:mb-10 text-sm sm:text-[16px]">
-        <%= f.label :firmness_percentage, t('activerecord.attributes.post.firmness'), class: "block text-neutral font-semibold mb-4 sm:mb-6" %>
+        <%= f.label :firmness_percentage, t('activerecord.attributes.post.firmness'), class: "block font-semibold mb-4 sm:mb-6" %>
         <%= f.range_field :firmness_percentage, in: 0..100, step: 1, class: "w-full custom-range-firmness", data: { action: "input->range-slider#updateStatus", range_slider_target: "range", attribute: "firmness" } %>
         <div class="w-full flex text-xs sm:text-sm justify-between px-2 mt-2">
           <div data-range-slider-target="statusText" data-status="smooth" data-attribute="firmness" class="w-1/3 text-center transition-all duration-300"><%= t('enums.post.firmness.smooth') %></div>
@@ -34,7 +34,7 @@
     </div>
 
     <div class="mb-8 sm:mb-10 text-sm sm:text-[16px]">
-      <%= f.label :overall_rating, class: "block text-neutral font-semibold mb-4 sm:mb-6" %>
+      <%= f.label :overall_rating, class: "block font-semibold mb-4 sm:mb-6" %>
       <div class="rating rating-lg flex justify-center space-x-2">
         <% Post.overall_ratings.each do |key, value| %>
           <%= f.radio_button :overall_rating, key, class: "mask mask-star-2 bg-accent" %>
@@ -43,12 +43,12 @@
     </div>
 
     <div class="mb-8 sm:mb-10 text-sm sm:text-[16px]">
-      <%= f.label :image, class: "block text-neutral font-semibold mb-2 sm:mb-4" %>
+      <%= f.label :image, class: "block font-semibold mb-2 sm:mb-4" %>
       <%= f.file_field :image, accept: 'image/*', class: "file-input custom-file-input" %>
     </div>
 
     <div class="mb-8 sm:mb-10 text-sm sm:text-[16px]">
-      <%= f.label :body, class: "block text-neutral font-semibold mb-2 sm:mb-4" %>
+      <%= f.label :body, class: "block font-semibold mb-2 sm:mb-4" %>
       <%= f.text_area :body, placeholder: t('posts.form.body_placeholder'), class: "textarea textarea-bordered w-full bg-white placeholder-placeholder text-sm placeholder:text-placeholder", rows: 4 %>
     </div>
 

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -67,8 +67,11 @@
               </div>
             </div>
           </div>
-          <p class="mb-2 sm:ml-1 text-sm sm:text-[16px] text-subtleText">
-            <i class="fa fa-map-marker-alt mr-2 text-accent"></i><%= post.shop&.address.present? ? post.shop.address : t('posts.address_not_registered') %>
+          <% if post.shop&.address.present? %>
+            <p class="mb-2 sm:ml-1 text-sm sm:text-[16px] text-subtleText">
+              <i class="fa fa-map-marker-alt mr-2 text-accent"></i><%= post.shop.address %>
+            </p> 
+          <% end %>
           <p class="sm:ml-0.5 text-sm sm:text-[16px] text-text text-opacity-80"><%= post.body.truncate(55) %></p>
         </div>
       </div>

--- a/app/views/posts/edit.html.erb
+++ b/app/views/posts/edit.html.erb
@@ -1,7 +1,7 @@
 <% content_for(:title, t('.title')) %>
-<div class="flex flex-col items-center justify-start min-h-screen bg-base pt-4 sm:pt-8 md:pt-12 lg:pt-16">
+<div class="flex flex-col items-center justify-start min-h-screen py-12 sm:py-16">
   <div class="w-full max-w-md px-4 sm:px-0">
-    <h1 class="text-2xl font-bold text-center mb-6"><%= t('posts.edit.title') %></h1>
+    <h1 class="text-xl sm:text-2xl font-bold text-center mb-4 sm:mb-6"><%= t('posts.edit.title') %></h1>
     <%= render 'form', post: @post %>
   </div>
 </div>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -1,7 +1,7 @@
 <% content_for(:title, t('.title')) %>
-<div class="flex flex-col items-center justify-start min-h-screen bg-base pt-4 sm:pt-8 md:pt-12 lg:pt-16">
+<div class="flex flex-col items-center justify-start min-h-screen py-12 sm:py-16">
   <div class="w-full max-w-md px-4 sm:px-0">
-    <h1 class="text-2xl font-bold text-center mb-6"><%= t('posts.new.title') %></h1>
+    <h1 class="text-xl sm:text-2xl font-bold text-center mb-4 sm:mb-6"><%= t('posts.new.title') %></h1>
     <%= render 'form', post: @post %>
   </div>
 </div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -118,9 +118,11 @@
     <hr class="my-4 mx-2 md:mx-6 border-placeholder">
 
     <!-- 住所 -->
-    <div class="px-4 sm:px-8 pb-4 text-sm sm:text-lg text-subtleText">
-      <i class="fas fa-map-marker-alt mr-2 text-accent"></i><%= @post.shop&.address.present? ? @post.shop.address : t('posts.address_not_registered') %>
-    </div>
+    <% if @post.shop&.address.present? %>
+      <div class="px-4 sm:px-8 pb-4 text-sm sm:text-lg text-subtleText">
+        <i class="fas fa-map-marker-alt mr-2 text-accent"></i><%= @post.shop.address %>
+      </div>
+    <% end %>
 
     <!-- Xシェア -->
     <div class="mt-4 sm:mt-6 mb-2 text-center">

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -48,7 +48,6 @@ ja:
       shop_address_placeholder: お店の住所を入力してください
       body_placeholder: プリンやお店の詳細を入力してください
     shop_name_default: お店
-    address_not_registered: 住所未登録
     index:
       no_posts: 投稿はありません
     search_form:


### PR DESCRIPTION
## 変更内容
以下の変更を行いました。

- **マイページ編集と投稿編集のプレビュー画像の表示を削除**
  - ActiveStorageではファイルを選択しただけではテーブルに保存されないため、元の記述では投稿された画像やアバターを編集画面で表示していました。しかし、画像を変更した際にプレビューが元の画像から変わらないため、ユーザーに編集できていないと誤解させる懸念があるため、プレビュー表示を削除しました。

- **住所がある場合のみ投稿詳細と投稿一覧に住所を表示**
  - 投稿詳細ページおよび投稿一覧ページで、住所が存在する場合のみ表示されるように条件を追加しました。これにより、住所が未登録の場合は何も表示されず、混乱を避けることができます。

- **投稿作成編集/ログイン新規登録/プロフィール編集ページの間隔調整**
  - レスポンシブ対応として、これらのページの間隔を調整しました。

## 動作確認項目
- [x] マイページ編集および投稿編集画面でプレビュー画像が表示されないことを確認。
- [x] 投稿詳細および投稿一覧で住所が存在する場合のみ表示されることを確認。
- [x] 投稿作成編集、ログイン新規登録、およびプロフィール編集ページで間隔が適切であることを確認（レスポンシブ対応）。

## 関連Issue
 - #180 

## その他
プレビュー画像表示については優先度が高いものではないと判断したため、本リリース後に以下にて実装予定です。
- #194 
