### PR TITLE
パスワードリセットへのリンクをコメントアウト

### DIFF
--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -32,8 +32,10 @@
       <div class="text-center mt-4 sm:mt-6 text-sm sm:text-[16px]">
         <%= t('devise.shared.links.sign_up_prompt') %><!--
         --><%= link_to t('devise.shared.links.here'), new_registration_path(resource_name), class: "text-accent hover:underline" %><br>
-        <%= t('devise.shared.links.forgot_password_prompt') %><!--
-        --><%= link_to t('devise.shared.links.here'), new_password_path(resource_name), class: "text-accent hover:underline" %>
+        
+        <%# パスワードリセット未実装のため以下コメントアウト %>
+        <%# t('devise.shared.links.forgot_password_prompt') %><!--
+        --><%# link_to t('devise.shared.links.here'), new_password_path(resource_name), class: "text-accent hover:underline" %>
       </div>
     </div>
   </div>


### PR DESCRIPTION
パスワードリセット機能は本リリースでの実装とするため、関連する記述をコメントアウトしました。