### PR TITLE
Add:カテゴリー機能の追加

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -110,6 +110,6 @@ class PostsController < ApplicationController
   end
 
   def post_params
-    params.require(:post).permit(:body, :sweetness_percentage, :firmness_percentage, :overall_rating, :shop_name, :shop_address, :image)
+    params.require(:post).permit(:body, :sweetness_percentage, :firmness_percentage, :overall_rating, :shop_name, :shop_address, :image, :category)
   end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -16,6 +16,7 @@ class Post < ApplicationRecord
   validates :firmness, presence: true
   validates :overall_rating, presence: true
   validates :sweetness_percentage, :firmness_percentage, presence: true, inclusion: { in: 0..100 }
+  validates :category, presence: true
 
   enum :sweetness, { mild: 0, medium_sweet: 1, sweet: 2 }
   enum :firmness, { smooth: 0, medium_firm: 1, firm: 2 }
@@ -26,11 +27,9 @@ class Post < ApplicationRecord
     good: 4,
     excellent: 5
   }
+  enum category: { cafe: 0, sweets_shop: 1, retail: 2 }, _prefix: true
 
   before_validation :set_sweetness_and_firmness
-
-  # 将来的に実装予定の機能のためのコメントアウト
-  # belongs_to :category
 
   def self.ransackable_attributes(auth_object = nil)
     ["body", "sweetness_percentage", "firmness_percentage", "sweetness", "firmness", "overall_rating", "created_at"]

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -27,7 +27,7 @@ class Post < ApplicationRecord
     good: 4,
     excellent: 5
   }
-  enum category: { cafe: 0, sweets_shop: 1, retail: 2 }, _prefix: true
+  enum :category, { cafe: 0, sweets_shop: 1, retail: 2 }, prefix: true
 
   before_validation :set_sweetness_and_firmness
 

--- a/app/models/shop.rb
+++ b/app/models/shop.rb
@@ -5,7 +5,6 @@ class Shop < ApplicationRecord
   validates :address, allow_blank: true, length: { maximum: 255 }
 
   # 将来的に実装予定の機能のためのコメントアウト
-  # belongs_to :category, optional: true
   # geocoded_by :address
   # after_validation :geocode, if: :address_changed?
 

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -5,7 +5,15 @@
       <%= f.label :shop_name, t('activerecord.attributes.shop.name'), class: "block font-semibold mb-2 sm:mb-4" %>
       <%= f.text_field :shop_name, placeholder: t('posts.form.shop_name_placeholder'), value: @post.shop_name || @post.shop&.name, class: "input input-bordered w-full bg-white text-sm sm:text-[16px] placeholder:text-sm placeholder:text-placeholder" %>
     </div>
-    
+
+    <div class="mb-8 sm:mb-10 text-sm sm:text-[16px]">
+      <%= f.label :category, class: "block font-semibold mb-2 sm:mb-4" %>
+      <%= f.select :category,
+                   Post.categories.keys.map { |s| [t("enums.post.category.#{s}"), s] }, 
+                   { prompt: t('defaults.select_prompt') }, 
+                   class: "select select-bordered w-full bg-white" %>
+    </div>
+
     <div class="mb-8 sm:mb-10 text-sm sm:text-[16px]">
       <%= f.label :shop_address, t('activerecord.attributes.shop.address'), class: "block font-semibold mb-2 sm:mb-4" %>
       <%= f.text_field :shop_address, placeholder: t('posts.form.shop_address_placeholder'), value: @post.shop_address || @post.shop&.address, class: "input input-bordered w-full bg-white text-sm sm:text-[16px] placeholder:text-sm placeholder:text-placeholder" %>

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -44,9 +44,10 @@
           </div>
         </div>
         <div class="w-full sm:w-3/5 p-4">
-          <h2 class="text-xl sm:text-2xl font-bold mb-3 mt-2 sm:mt-8 text-center sm:text-left">
+          <h2 class="text-xs md:text-sm text-subtleText mt-2 mb-1 sm:mb-2 text-center sm:text-left"><%= t("enums.post.category.#{post.category}") %></h2>
+          <h1 class="text-xl sm:text-2xl font-bold mb-3 text-center sm:text-left">
             <%= link_to post.shop.name, post_path(post), data: { turbo_frame: "_top" } %>
-          </h2>
+          </h1>
           <div class="flex justify-center sm:justify-start mb-4 space-x-1">
             <% Post.overall_ratings.size.times do |i| %>
               <span 

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -43,20 +43,21 @@
       <% end %>
     </div>
 
+    <!-- カテゴリー -->
+    <h2 class="text-sm md:text-[16px] mt-8 sm:mt-10 mb-1 sm:mb-2 text-center"><%= t("enums.post.category.#{@post.category}") %></h2>
+
     <!-- 店舗名 -->
-    <h1 class="text-2xl md:text-3xl font-bold my-8 text-center"><%= @post.shop.name %></h1>
+    <h1 class="text-2xl md:text-3xl font-bold mb-8 sm:mb-10 text-center"><%= @post.shop.name %></h1>
 
     <!-- 投稿画像 -->
     <% if @post.image.attached? %>
-      <div class="w-11/12 mx-auto aspect-square rounded-sm flex items-center justify-center mt-6 sm:mt-8 mb-6  sm:mb-8 overflow-hidden">
+      <div class="w-11/12 mx-auto aspect-square rounded-sm flex items-center justify-center mb-10 overflow-hidden">
         <%= image_tag @post.image.variant(resize_to_fill: [1000, 1000], format: :webp), class: "w-full h-full object-cover" %>
       </div>
-    <% else %>
-      <div class="mb-6 sm:mb-8"></div>
     <% end %>
 
     <!-- コメント -->
-    <div class="px-6 md:px-12 lg:px-16 py-4">
+    <div class="px-6 md:px-12 lg:px-16 pb-4">
       <%= simple_format(@post.body, class: "text-sm sm:text-lg text-left break-words text-text text-opacity-80") %>
     </div>
 

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -44,7 +44,7 @@
     </div>
 
     <!-- カテゴリー -->
-    <h2 class="text-sm md:text-[16px] mt-8 sm:mt-10 mb-1 sm:mb-2 text-center"><%= t("enums.post.category.#{@post.category}") %></h2>
+    <h2 class="text-sm md:text-[16px] text-text text-opacity-70 mt-8 sm:mt-10 mb-1 sm:mb-2 text-center"><%= t("enums.post.category.#{@post.category}") %></h2>
 
     <!-- 店舗名 -->
     <h1 class="text-2xl md:text-3xl font-bold mb-8 sm:mb-10 text-center"><%= @post.shop.name %></h1>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -15,6 +15,10 @@ ja:
         ordinary: "3"
         good: "4"
         excellent: "5"
+      category:
+        cafe: カフェ・喫茶店
+        sweets_shop: 洋菓子店
+        retail: 市販品（コンビニ/スーパー等）
   activerecord:
     models:
       post: 投稿

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -30,6 +30,7 @@ ja:
         firmness: 固さ
         overall_rating: 総合評価
         image: プリンの写真
+        category: お店の種類
       shop:
         name: お店
         address: 住所

--- a/db/migrate/20241109070814_add_category_to_posts.rb
+++ b/db/migrate/20241109070814_add_category_to_posts.rb
@@ -1,0 +1,18 @@
+class AddCategoryToPosts < ActiveRecord::Migration[7.2]
+  def up
+    add_column :posts, :category, :integer
+
+    # 既存のすべての投稿を'cafe'カテゴリーに設定
+    Post.update_all(category: 0)
+
+    # カラムにNOT NULL制約を追加
+    change_column_null :posts, :category, false
+
+    add_index :posts, :category
+  end
+
+  def down
+    remove_index :posts, :category
+    remove_column :posts, :category
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_11_06_105617) do
+ActiveRecord::Schema[7.2].define(version: 2024_11_09_070814) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -63,6 +63,8 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_06_105617) do
     t.datetime "updated_at", null: false
     t.integer "sweetness_percentage", null: false
     t.integer "firmness_percentage", null: false
+    t.integer "category", null: false
+    t.index ["category"], name: "index_posts_on_category"
     t.index ["firmness"], name: "index_posts_on_firmness"
     t.index ["overall_rating"], name: "index_posts_on_overall_rating"
     t.index ["shop_id", "user_id"], name: "index_posts_on_shop_id_and_user_id"


### PR DESCRIPTION
## 変更内容
お店の種類を「カフェ・喫茶店」「洋菓子店」「市販品（コンビニ・スーパー等）」から選択できるように、
postsテーブルにcategoryカラムを追加しました。
- [ ] [postsテーブルにcategoryカラムの追加](https://github.com/jyasco/purin-mania/commit/e84f19b197ee21476f03ad9a058edfad8dc0e2a2)
- [ ] [categoryの日本語化](https://github.com/jyasco/purin-mania/commit/f439865e9bffe2c199a61808c7f25ba5609fe3e8)
- [ ] [_form.html.erbを修正](https://github.com/jyasco/purin-mania/commit/be055ce4be6d58af38dea49c7f23b70f069a945a)
- [ ] [posts_controller.rbを修正](https://github.com/jyasco/purin-mania/commit/4ef6720390154ec4fa59dc4a5cef91a91082a339)
- [ ] [show.html.erbを修正](https://github.com/jyasco/purin-mania/commit/16cecf559ed4eb778a01206d7060449ed57dee24)
- [ ] [_post.html.erbを修正](https://github.com/jyasco/purin-mania/commit/83faff1bed2917f363cbdee60eb6fd4b8bac8b84)

## 関連ISSUE
- #49 
- #50 

## その他
**元々categoriesテーブルを別途作成予定でしたが、以下の観点からpostsテーブルにカラムを追加する手順に変更しました。**
- カテゴリーの内容が変わる可能性が低いこと
- 複雑な階層などを持つ予定がないこと
- データベース構造がシンプルになり、管理が容易になるメリットがあること
- 別テーブルとのJOINが不要になるため、クエリのパフォーマンスが向上するメリットがあること

**enumの記述に関しては、rails7.1以降enumにprefixを記述することが推奨されているため、記述しています。**