### PR TITLE
add:カテゴリーの絞り込み検索を追加

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -32,7 +32,7 @@ class Post < ApplicationRecord
   before_validation :set_sweetness_and_firmness
 
   def self.ransackable_attributes(auth_object = nil)
-    ["body", "sweetness_percentage", "firmness_percentage", "sweetness", "firmness", "overall_rating", "created_at"]
+    ["category","body", "sweetness_percentage", "firmness_percentage", "sweetness", "firmness", "overall_rating", "created_at"]
   end
 
   def self.ransackable_associations(auth_object = nil)

--- a/app/views/posts/_search_form.html.erb
+++ b/app/views/posts/_search_form.html.erb
@@ -40,11 +40,11 @@
             data: { search_clear_target: "select" } %>
       </div>
 
-      <!-- 総合評価の絞り込み -->
+      <!-- カテゴリーの絞り込み -->
       <div class="col-span-1">
-        <%= f.select :overall_rating_eq,
-            Post.overall_ratings.map { |k, v| [t("enums.post.overall_rating.#{k}"), v] },
-            { include_blank: t('.overall_rating') },
+        <%= f.select :category_eq,
+            Post.categories.map { |k, v| [t("enums.post.category.#{k}"), v] },
+            { include_blank: t('.category') },
             class: 'select select-bordered w-full text-xs sm:text-sm bg-white',
             data: { search_clear_target: "select" } %>
       </div>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -57,6 +57,7 @@ ja:
       sweetness: 甘さ
       firmness: 固さ
       overall_rating: 評価
+      category: 店舗種類
       sort: 並び替え
       highest_rated: 評価が高い順
       lowest_rated: 評価が低い順


### PR DESCRIPTION
## 変更内容
検索フォームにて、カテゴリーでの絞り込み検索を追加しました。
また、評価の並び替え検索が行えるため評価の絞り込み検索は需要が低いと考え、削除しました。

## 関連ISSUE
- #207 