### PR TITLE
Add/プロフィールに好みとコメントを追加

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,7 +7,7 @@ class ApplicationController < ActionController::Base
 
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:sign_up, keys: [:name])
-    devise_parameter_sanitizer.permit(:account_update, keys: [:name, :avatar])
+    devise_parameter_sanitizer.permit(:account_update, keys: [:name, :avatar:comment, :preferred_sweetness, :preferred_firmness]])
   end
 
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,7 +7,7 @@ class ApplicationController < ActionController::Base
 
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:sign_up, keys: [:name])
-    devise_parameter_sanitizer.permit(:account_update, keys: [:name, :avatar:comment, :preferred_sweetness, :preferred_firmness]])
+    devise_parameter_sanitizer.permit(:account_update, keys: [:name, :avatar, :comment, :preferred_sweetness, :preferred_firmness])
   end
 
 end

--- a/app/controllers/mypage/bookmark_posts_controller.rb
+++ b/app/controllers/mypage/bookmark_posts_controller.rb
@@ -2,6 +2,7 @@ class Mypage::BookmarkPostsController < ApplicationController
   before_action :authenticate_user!
 
   def index
+    @user = current_user
     @bookmarked_posts = current_user.bookmark_posts.includes(:user).order(created_at: :desc)
   end
 end

--- a/app/controllers/mypage/posts_controller.rb
+++ b/app/controllers/mypage/posts_controller.rb
@@ -2,6 +2,7 @@ class Mypage::PostsController < ApplicationController
   before_action :authenticate_user!
 
   def index
+    @user = current_user
     @posts = current_user.posts.includes(:user).order(created_at: :desc)
   end
 end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -47,7 +47,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
 
   # If you have extra params to permit, append them to the sanitizer.
   def configure_account_update_params
-    devise_parameter_sanitizer.permit(:account_update, keys: [:name, :avatar:comment, :preferred_sweetness, :preferred_firmness])
+    devise_parameter_sanitizer.permit(:account_update, keys: [:name, :avatar, :comment, :preferred_sweetness, :preferred_firmness])
   end
 
   # The path used after sign up.

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -47,7 +47,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
 
   # If you have extra params to permit, append them to the sanitizer.
   def configure_account_update_params
-    devise_parameter_sanitizer.permit(:account_update, keys: [:name, :avatar])
+    devise_parameter_sanitizer.permit(:account_update, keys: [:name, :avatar:comment, :preferred_sweetness, :preferred_firmness])
   end
 
   # The path used after sign up.

--- a/app/javascript/custom/select_placeholder.js
+++ b/app/javascript/custom/select_placeholder.js
@@ -13,7 +13,7 @@ document.addEventListener('turbo:load', function() {
 
     // フォーカス時の処理
     select.addEventListener('focus', function() {
-      if (this.value === '') {
+      if (this.value === '' && !this.classList.contains('select-keep-blank')) {
         placeholder.hidden = true;
       }
     });

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -27,7 +27,7 @@ class Post < ApplicationRecord
     good: 4,
     excellent: 5
   }
-  enum :category, { cafe: 0, sweets_shop: 1, retail: 2 }, prefix: true
+  enum :category, { cafe: 0, sweets_shop: 1, retail: 2 }
 
   before_validation :set_sweetness_and_firmness
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,7 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable
 
   validates :name, presence: true, length: { maximum: 50 }
+  validates :comment, length: { maximum: 50 }
 
   has_many :posts
   has_many :bookmarks, dependent: :destroy

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,7 +4,7 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 
-  validates :name, presence: true, length: { maximum: 50 }
+  validates :name, presence: true, length: { maximum: 30 }
   validates :comment, length: { maximum: 50 }
 
   has_many :posts

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,6 +11,9 @@ class User < ApplicationRecord
   has_many :bookmark_posts, through: :bookmarks, source: :post
   has_one_attached :avatar
 
+  enum :preferred_sweetness, { prefer_mild: 0, prefer_medium_sweet: 1, prefer_sweet: 2 }
+  enum :preferred_firmness, { prefer_smooth: 0, prefer_medium_firm: 1, prefer_firm: 2 }
+
   def own?(object)
     object&.user_id == id
   end

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -13,8 +13,32 @@
         </div>
 
         <div class="mb-8 sm:mb-10 text-sm sm:text-[16px]">
+          <%= f.label :email, class: "block font-semibold mb-2 sm:mb-4" %>
+          <%= f.text_field :email, class: "input input-bordered w-full bg-white" %>
+        </div>
+        
+        <div class="mb-8 sm:mb-10 text-sm sm:text-[16px]">
+          <%= f.label :preferred_sweetness, class: "block font-semibold mb-2 sm:mb-4" %>
+          <%= f.select :preferred_sweetness, User.preferred_sweetnesses.keys.map { |k| [t("enums.user.preferred_sweetness.#{k}"), k] },
+              { include_blank: t('defaults.unset') },
+              class: "select select-bordered select-keep-blank w-full text-xs sm:text-sm bg-white" %>
+        </div>
+        
+        <div class="mb-8 sm:mb-10 text-sm sm:text-[16px]">
+          <%= f.label :preferred_firmness, class: "block font-semibold mb-2 sm:mb-4" %>
+          <%= f.select :preferred_firmness, User.preferred_firmnesses.keys.map { |k| [t("enums.user.preferred_firmness.#{k}"), k] },
+              { include_blank: t('defaults.unset') },
+              class: "select select-bordered select-keep-blank w-full text-xs sm:text-sm bg-white" %>
+        </div>
+
+        <div class="mb-8 sm:mb-10 text-sm sm:text-[16px]">
           <%= f.label :avatar, class: "block font-semibold mb-2 sm:mb-4" %>
           <%= f.file_field :avatar, accept: 'image/*', class: "file-input custom-file-input" %>
+        </div>
+
+        <div class="mb-8 sm:mb-10 text-sm sm:text-[16px]">
+          <%= f.label :comment, class: "block font-semibold mb-2 sm:mb-4" %>
+          <%= f.text_area :comment, class: "textarea textarea-bordered w-full bg-white" %>
         </div>
 
         <div class="text-center mt-12 sm:mt-16">

--- a/app/views/mypage/bookmark_posts/index.html.erb
+++ b/app/views/mypage/bookmark_posts/index.html.erb
@@ -1,6 +1,6 @@
 <% content_for(:title, t('mypage.title')) %>
 <div class="bg-base-100 min-h-screen mb-6 sm:mb-0">
-  <%= render 'mypage/shared/profile' %>
+  <%= render 'mypage/shared/profile', user: @user %>
   <%= render 'mypage/shared/nav_buttons' %>
 
   <%= turbo_frame_tag "mypage_content" do %>

--- a/app/views/mypage/posts/index.html.erb
+++ b/app/views/mypage/posts/index.html.erb
@@ -1,6 +1,6 @@
 <% content_for(:title, t('mypage.title')) %>
 <div class="bg-base-100 min-h-screen mb-6 sm:mb-0">
-  <%= render 'mypage/shared/profile' %>
+  <%= render 'mypage/shared/profile', user: @user %>
   <%= render 'mypage/shared/nav_buttons' %>
 
   <%= turbo_frame_tag "mypage_content" do %>

--- a/app/views/mypage/shared/_profile.html.erb
+++ b/app/views/mypage/shared/_profile.html.erb
@@ -1,15 +1,43 @@
-<div class="flex flex-col items-center py-8 bg-base-100">
-  <div class="avatar">
-    <div class="w-20 h-20 sm:w-24 sm:h-24 rounded-full overflow-hidden">
-      <% if current_user.avatar.attached? %>
-        <%= image_tag current_user.avatar.variant(resize_to_fill: [96, 96]), class: "w-full h-full object-cover" %>
-      <% else %>
-        <%= image_tag "default_avatar.webp", class: "w-full h-full object-cover" %>
+<div class="container mx-auto flex py-8 px-8 sm:px-4 max-w-sm sm:max-w-2xl relative">
+
+  <!-- アバターとユーザー名 -->
+  <div class="flex flex-col items-center w-2/5 sm:pl-8">
+    <!-- アバター -->
+    <div class="sm:mt-1">
+      <div class="w-16 h-16 sm:w-24 sm:h-24 rounded-full overflow-hidden">
+        <% if user.avatar.attached? %>
+          <%= image_tag user.avatar.variant(resize_to_fill: [96, 96]), class: "w-full h-full object-cover" %>
+        <% else %>
+          <%= image_tag "default_avatar.webp", class: "w-full h-full object-cover" %>
+        <% end %>
+      </div>
+    </div>
+    <!-- ユーザー名と編集 -->
+    <div class="flex items-center mt-2 sm:mt-4 space-x-1 sm:space-x-2">
+      <h2 class="text-sm sm:text-xl font-bold"><%= user.name %></h2>
+      <%= link_to edit_user_registration_path, class: "text-accent hover:text-hover" do %>
+        <i class="fas fa-pen text-xs sm:text-sm"></i>
       <% end %>
     </div>
   </div>
-  <h2 class="text-neutral text-lg sm:text-2xl font-bold mt-4"><%= current_user.name %></h2>
-  <%= link_to edit_user_registration_path, class: "btn btn-primary btn-sm w-16 h-9 sm:w-20 sm:h-10 mt-4 px-4 text-white" do %>
-    <%= t('helpers.submit.edit') %>
-  <% end %>
+
+  <!-- 好みのプリンとコメント -->
+  <div class="flex flex-col justify-center w-3/5 px-2 sm:px-8 text-left">
+    <div class="text-[14px] sm:text-[18px]">
+      <%= t('mypage.edit.preferences') %>:
+      <% if user.preferred_sweetness.present? %>
+        <%= t("enums.user.preferred_sweetness.#{user.preferred_sweetness}") %>
+      <% else %>  
+        <%= t('mypage.edit.unset') %>
+      <% end %>
+      <% if user.preferred_firmness.present? %>
+        <%= t("enums.user.preferred_firmness.#{user.preferred_firmness}") %>
+      <% else %>  
+        <%= t('mypage.edit.unset') %>
+      <% end %>
+    </div>
+    <% if user.comment.present? %>
+      <p class="mt-1 pr-4 sm:mt-2 pr-6 text-[12px] sm:text-[16px] text-text text-opacity-70"><%= user.comment %></p>
+    <% end %>
+  </div>
 </div>

--- a/app/views/mypage/shared/_profile.html.erb
+++ b/app/views/mypage/shared/_profile.html.erb
@@ -13,16 +13,16 @@
       </div>
     </div>
     <!-- ユーザー名と編集 -->
-    <div class="flex items-center mt-2 sm:mt-4 space-x-1 sm:space-x-2">
-      <h2 class="text-sm sm:text-xl font-bold truncate max-w-[100px] sm:max-w-[200px]"><%= user.name %></h2>
-      <%= link_to edit_user_registration_path, class: "text-accent hover:text-hover" do %>
+    <div class="flex items-center mt-2 sm:mt-4 space-x-1 sm:space-x-2 relative">
+      <h2 class="text-[14px] sm:text-lg font-bold truncate max-w-[120px] sm:max-w-[200px]"><%= user.name %></h2>
+      <%= link_to edit_user_registration_path, class: "text-accent hover:text-hover z-[10]" do %>
         <i class="fas fa-pen text-xs sm:text-sm"></i>
       <% end %>
     </div>
   </div>
 
   <!-- 好みのプリンとコメント -->
-  <div class="flex flex-col justify-center w-3/5 px-2 sm:px-8 text-left">
+  <div class="flex flex-col justify-center w-3/5 px-4 sm:px-8 text-left">
     <div class="text-[14px] sm:text-[18px]">
       <%= t('mypage.edit.preferences') %>:
       <% if user.preferred_sweetness.present? %>
@@ -37,7 +37,7 @@
       <% end %>
     </div>
     <% if user.comment.present? %>
-      <p class="mt-1 pr-4 sm:mt-2 pr-6 text-[12px] sm:text-[16px] text-text text-opacity-70"><%= user.comment %></p>
+      <p class="mt-1 sm:mt-2 sm:pr-10 text-[12px] sm:text-[16px] text-text text-opacity-70"><%= user.comment %></p>
     <% end %>
   </div>
 </div>

--- a/app/views/mypage/shared/_profile.html.erb
+++ b/app/views/mypage/shared/_profile.html.erb
@@ -14,7 +14,7 @@
     </div>
     <!-- ユーザー名と編集 -->
     <div class="flex items-center mt-2 sm:mt-4 space-x-1 sm:space-x-2">
-      <h2 class="text-sm sm:text-xl font-bold"><%= user.name %></h2>
+      <h2 class="text-sm sm:text-xl font-bold truncate max-w-[100px] sm:max-w-[200px]"><%= user.name %></h2>
       <%= link_to edit_user_registration_path, class: "text-accent hover:text-hover" do %>
         <i class="fas fa-pen text-xs sm:text-sm"></i>
       <% end %>

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -30,7 +30,7 @@
               <% end %>
             </div>
             <div class="flex flex-col justify-center overflow-hidden">
-              <p class="text-sm font-semibold truncate max-w-[120px] sm:max-w-[150px]"><%= post.user.name %></p>
+              <p class="text-sm font-semibold truncate max-w-[160px] sm:max-w-[200px]"><%= post.user.name %></p>
               <p class="text-xs text-subtleText pl-0.5"><%= post.created_at.strftime("%Y/%m/%d") %></p>
             </div>
           </div>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -19,6 +19,15 @@ ja:
         cafe: カフェ・喫茶店
         sweets_shop: 洋菓子店
         retail: 市販品（コンビニ・スーパー等）
+    user:
+      preferred_sweetness:
+        prefer_mild: 控えめ
+        prefer_medium_sweet: ほどよい
+        prefer_sweet: 甘党向け
+      preferred_firmness:
+        prefer_smooth: なめらか
+        prefer_medium_firm: ほどよい
+        prefer_firm: かため
   activerecord:
     models:
       post: 投稿

--- a/config/locales/devise.views.ja.yml
+++ b/config/locales/devise.views.ja.yml
@@ -27,6 +27,9 @@ ja:
         updated_at: 更新日
         name: ユーザー名
         avatar: プロフィール画像
+        comment: コメント
+        prefer_sweetness: 甘さの好み
+        prefer_firmness: 固さの好み
     models:
       user: ユーザー
   devise:

--- a/config/locales/devise.views.ja.yml
+++ b/config/locales/devise.views.ja.yml
@@ -28,8 +28,8 @@ ja:
         name: ユーザー名
         avatar: プロフィール画像
         comment: コメント
-        prefer_sweetness: 甘さの好み
-        prefer_firmness: 固さの好み
+        preferred_sweetness: 甘さの好み
+        preferred_firmness: 固さの好み
     models:
       user: ユーザー
   devise:

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -71,6 +71,8 @@ ja:
     title: マイページ
     edit:
       title: プロフィール編集
+      preferences: 好み
+      unset: 未設定
     bookmark_posts:
       list:
         no_posts: 保存しているプリンはありません

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -14,7 +14,7 @@ ja:
     create: 作成
     post: 投稿
     delete_confirm: 削除しますか？
-    select_prompt: 選択してください
+    unset: 未設定
     search_word: エリア・店名など
     flash_message:
       created: "%{item}を作成しました"

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -14,6 +14,7 @@ ja:
     create: 作成
     post: 投稿
     delete_confirm: 削除しますか？
+    select_prompt: 選択してください
     unset: 未設定
     search_word: エリア・店名など
     flash_message:

--- a/db/migrate/20241110044703_add_preferences_to_users.rb
+++ b/db/migrate/20241110044703_add_preferences_to_users.rb
@@ -1,0 +1,7 @@
+class AddPreferencesToUsers < ActiveRecord::Migration[7.2]
+  def change
+    add_column :users, :comment, :text
+    add_column :users, :preferred_sweetness, :integer
+    add_column :users, :preferred_firmness, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_11_09_070814) do
+ActiveRecord::Schema[7.2].define(version: 2024_11_10_044703) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -90,6 +90,9 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_09_070814) do
     t.datetime "remember_created_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.text "comment"
+    t.integer "preferred_sweetness"
+    t.integer "preferred_firmness"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["name"], name: "index_users_on_name"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true


### PR DESCRIPTION
## 変更内容
プロフィールに甘さと固さの好みと、コメントを追加しました。
- [x] Usersテーブルにカラムを追加
- [x] パラメータに追加したカラムを記述
- [x] Userモデルにバリデーションとenumを追加
- [x] ja.ymlに日本語化の記述
- [x] プロフィール編集ページにフィールドを追加
- [x] マイページにコメントと好みを表示
- [x] 表示される文字制限(truncate)を追加

## 参考
https://www.notion.so/13a9ca21c80580c99c85f349440abc2b?pvs=4

## 関連ISSUE
- #200 