### PR TITLE
Fix/profile design

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -10,6 +10,32 @@ module ApplicationHelper
     end
   end
 
+  def sweetness_badge_color(sweetness)
+    case sweetness
+    when 'mild', 'prefer_mild'
+      'bg-sweetLight text-textLight'
+    when 'medium_sweet', 'prefer_medium_sweet'
+      'bg-sweetMedium text-textLight'
+    when 'sweet', 'prefer_sweet'
+      'bg-sweetDeep text-textLight'
+    else
+      'bg-gray-400 text-textLight'
+    end
+  end
+
+  def firmness_badge_color(firmness)
+    case firmness
+    when 'smooth', 'prefer_smooth'
+      'bg-firmLight text-textLight'
+    when 'medium_firm', 'prefer_medium_firm'
+      'bg-firmMedium text-textLight'
+    when 'firm', 'prefer_firm'
+      'bg-firmDeep text-textLight'
+    else
+      'bg-gray-400 text-textLight'
+    end
+  end
+
   def show_meta_tags
     assign_meta_tags if display_meta_tags.blank?
     display_meta_tags

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,3 +1,3 @@
-module PostsHelper
+module UsersHelper
   include ApplicationHelper
 end

--- a/app/views/mypage/shared/_profile.html.erb
+++ b/app/views/mypage/shared/_profile.html.erb
@@ -23,21 +23,19 @@
 
   <!-- 好みのプリンとコメント -->
   <div class="flex flex-col justify-center w-3/5 px-4 sm:px-8 text-left">
-    <div class="text-[14px] sm:text-[18px]">
-      <%= t('mypage.edit.preferences') %>:
-      <% if user.preferred_sweetness.present? %>
-        <%= t("enums.user.preferred_sweetness.#{user.preferred_sweetness}") %>
-      <% else %>  
-        <%= t('mypage.edit.unset') %>
-      <% end %>
-      <% if user.preferred_firmness.present? %>
-        <%= t("enums.user.preferred_firmness.#{user.preferred_firmness}") %>
-      <% else %>  
-        <%= t('mypage.edit.unset') %>
-      <% end %>
+    <div class="flex flex-col items-start">
+      <div class="text-[10px] sm:text-[14px] text-text text-opacity-80"><%= t('mypage.edit.preferences') %></div>
+      <div class="flex gap-1 mt-1 overflow-x-auto pb-1 w-full">
+        <span class="badge text-xs sm:text-sm py-2 sm:py-2.5 whitespace-nowrap <%= sweetness_badge_color(user.preferred_sweetness) %>">
+          <%= user.preferred_sweetness.present? ? t("enums.user.preferred_sweetness.#{user.preferred_sweetness}") : t('mypage.edit.unset') %>
+        </span>
+        <span class="badge text-xs sm:text-sm py-2 sm:py-2.5 whitespace-nowrap <%= firmness_badge_color(user.preferred_firmness) %>">
+          <%= user.preferred_firmness.present? ? t("enums.user.preferred_firmness.#{user.preferred_firmness}") : t('mypage.edit.unset') %>
+        </span>
+      </div>
     </div>
     <% if user.comment.present? %>
-      <p class="mt-1 sm:mt-2 sm:pr-10 text-[12px] sm:text-[16px] text-text text-opacity-70"><%= user.comment %></p>
+      <p class="mt-1 sm:mt-2 sm:pr-10 text-[12px] sm:text-[16px] text-text text-opacity-80"><%= user.comment %></p>
     <% end %>
   </div>
 </div>

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -30,7 +30,7 @@
               <% end %>
             </div>
             <div class="flex flex-col justify-center overflow-hidden">
-              <p class="text-sm font-semibold truncate max-w-[160px] sm:max-w-[200px]"><%= post.user.name %></p>
+              <p class="text-[12px] sm:text-[14px] truncate max-w-[160px] sm:max-w-[200px]"><%= post.user.name %></p>
               <p class="text-xs text-subtleText pl-0.5"><%= post.created_at.strftime("%Y/%m/%d") %></p>
             </div>
           </div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -20,7 +20,7 @@
           <% end %>
         </div>
         <div class="flex flex-col justify-center">
-          <p class="text-sm sm:text-[16px] font-semibold truncate max-w-[120px] sm:max-w-[200px]"><%= @post.user.name %></p>
+          <p class="text-[12px] sm:text-[14px] truncate max-w-[120px] sm:max-w-[200px]"><%= @post.user.name %></p>
           <p class="text-xs sm:text-sm text-subtleText whitespace-nowrap pl-0.5"><%= @post.created_at.strftime("%Y/%m/%d %H:%M") %></p>
         </div>
       </div>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -72,7 +72,7 @@ ja:
     title: マイページ
     edit:
       title: プロフィール編集
-      preferences: 好み
+      preferences: プリンの好み
       unset: 未設定
     bookmark_posts:
       list:


### PR DESCRIPTION
## 変更内容
- マイページに表示している好みのプリンにbadgeコンポーネントのデザインをあてました。
- 元々`posts_helper`に記述していた`sweetness_badge_color`と`firmness_badge_color`を`application_helper`に移動し、
`users_helper.rb`と`posts_helper`の両方で使用できるように拡張しました。
- マイページで好みを設定していない場合「未設定」と表示されるように記述しました
- 投稿一覧と投稿詳細のユーザー名のサイズをレスポンシブに調整しました。

## 参考
https://www.notion.so/badge-13a9ca21c805805c9429e1127dc69edf?pvs=4

## 関連ISSUE
- #214 