### PR TITLE
Fix/Userカラムの修正

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,7 +6,7 @@ class ApplicationController < ActionController::Base
   protected
 
   def configure_permitted_parameters
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:username, :nickname])
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:username])
     devise_parameter_sanitizer.permit(:account_update, keys: [:username, :nickname, :avatar, :comment, :preferred_sweetness, :preferred_firmness])
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,8 +6,8 @@ class ApplicationController < ActionController::Base
   protected
 
   def configure_permitted_parameters
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:name])
-    devise_parameter_sanitizer.permit(:account_update, keys: [:name, :avatar, :comment, :preferred_sweetness, :preferred_firmness])
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:username, :nickname])
+    devise_parameter_sanitizer.permit(:account_update, keys: [:username, :nickname, :avatar, :comment, :preferred_sweetness, :preferred_firmness])
   end
 
 end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -42,7 +42,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
 
   # If you have extra params to permit, append them to the sanitizer.
   def configure_sign_up_params
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:username, :nickname])
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:username])
   end
 
   # If you have extra params to permit, append them to the sanitizer.

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -42,12 +42,12 @@ class Users::RegistrationsController < Devise::RegistrationsController
 
   # If you have extra params to permit, append them to the sanitizer.
   def configure_sign_up_params
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:name])
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:username, :nickname])
   end
 
   # If you have extra params to permit, append them to the sanitizer.
   def configure_account_update_params
-    devise_parameter_sanitizer.permit(:account_update, keys: [:name, :avatar, :comment, :preferred_sweetness, :preferred_firmness])
+    devise_parameter_sanitizer.permit(:account_update, keys: [:username, :nickname, :avatar, :comment, :preferred_sweetness, :preferred_firmness])
   end
 
   # The path used after sign up.

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -27,7 +27,7 @@ class User < ApplicationRecord
   end
 
   def self.ransackable_attributes(auth_object = nil)
-    ["name"]
+    ["nickname","username"]
   end
 
   def update_avatar(new_avatar)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,7 +4,11 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 
-  validates :name, presence: true, length: { maximum: 30 }
+  validates :nickname, presence: true, length: { maximum: 30 }
+  validates :username, presence: true,
+             uniqueness: { case_sensitive: false },
+             format: { with: /\A[a-zA-Z0-9_.~-]+\z/, message: "は半角英数字、アンダースコア、ハイフン、ピリオド、チルドのみ使用できます" },
+             length: { minimum: 3, maximum: 20 }
   validates :comment, length: { maximum: 50 }
 
   has_many :posts

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,12 +3,15 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+  
+  VALID_USERNAMES = %w[contact terms privacy login logout sign_up posts profile settings help about]
 
   validates :nickname, presence: true, length: { maximum: 30 }
   validates :username, presence: true,
              uniqueness: { case_sensitive: false },
              format: { with: /\A[a-zA-Z0-9_.~-]+\z/, message: "は半角英数字、アンダースコア、ハイフン、ピリオド、チルドのみ使用できます" },
-             length: { minimum: 3, maximum: 20 }
+             length: { minimum: 3, maximum: 20 },
+             exclusion: { in: VALID_USERNAMES, message: "は使用できません" }
   validates :comment, length: { maximum: 50 }
 
   has_many :posts

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -22,6 +22,8 @@ class User < ApplicationRecord
   enum :preferred_sweetness, { prefer_mild: 0, prefer_medium_sweet: 1, prefer_sweet: 2 }
   enum :preferred_firmness, { prefer_smooth: 0, prefer_medium_firm: 1, prefer_firm: 2 }
 
+  before_validation :set_default_nickname
+
   def own?(object)
     object&.user_id == id
   end
@@ -45,5 +47,11 @@ class User < ApplicationRecord
 
   def bookmark?(post)
     bookmark_posts.include?(post)
+  end
+
+  private
+
+  def set_default_nickname
+    self.nickname = username unless nickname.present?
   end
 end

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -8,8 +8,13 @@
         <%= render "devise/shared/error_messages", resource: resource %>
 
         <div class="mb-8 sm:mb-10 text-sm sm:text-[16px]">
-          <%= f.label :name, class: "block font-semibold mb-2 sm:mb-4" %>
-          <%= f.text_field :name, class: "input input-bordered w-full bg-white" %>
+          <%= f.label :nickname, class: "block font-semibold mb-2 sm:mb-4" %>
+          <%= f.text_field :nickname, class: "input input-bordered w-full bg-white" %>
+        </div>
+
+        <div class="mb-8 sm:mb-10 text-sm sm:text-[16px]">
+          <%= f.label :username, class: "block font-semibold mb-2 sm:mb-4" %>
+          <%= f.text_field :username, class: "input input-bordered w-full bg-white" %>
         </div>
 
         <div class="mb-8 sm:mb-10 text-sm sm:text-[16px]">

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -8,8 +8,8 @@
         <%= render 'shared/error_messages', object: f.object %>
         
         <div class="mb-8 sm:mb-10 text-sm sm:text-[16px]">
-          <%= f.label :name, class: "block font-semibold mb-2 sm:mb-4" %>
-          <%= f.text_field :name, autofocus: true, class: "input input-bordered w-full bg-white" %>
+          <%= f.label :username, class: "block font-semibold mb-2 sm:mb-4" %>
+          <%= f.text_field :username, autofocus: true, class: "input input-bordered w-full bg-white" %>
         </div>
         
         <div class="mb-8 sm:mb-10 text-sm sm:text-[16px]">

--- a/app/views/mypage/shared/_profile.html.erb
+++ b/app/views/mypage/shared/_profile.html.erb
@@ -8,7 +8,7 @@
         <% if user.avatar.attached? %>
           <%= image_tag user.avatar.variant(resize_to_fill: [96, 96]), class: "w-full h-full object-cover" %>
         <% else %>
-          <%= image_tag "default_avatar.webp", class: "w-full h-full object-cover" %>
+          <%= image_tag "default_avatar.png", class: "w-full h-full object-cover" %>
         <% end %>
       </div>
     </div>

--- a/app/views/mypage/shared/_profile.html.erb
+++ b/app/views/mypage/shared/_profile.html.erb
@@ -14,7 +14,7 @@
     </div>
     <!-- ユーザー名と編集 -->
     <div class="flex items-center mt-1 sm:mt-2 space-x-1 sm:space-x-2 relative">
-      <h2 class="text-[14px] sm:text-lg font-bold truncate max-w-[120px] sm:max-w-[200px]"><%= user.name %></h2>
+      <h2 class="text-[14px] sm:text-lg font-bold truncate max-w-[120px] sm:max-w-[200px]"><%= user.nickname %></h2>
       <%= link_to edit_user_registration_path, class: "text-accent hover:text-hover z-[10]" do %>
         <i class="fas fa-pen text-xs sm:text-sm"></i>
       <% end %>

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -30,7 +30,7 @@
               <% end %>
             </div>
             <div class="flex flex-col justify-center overflow-hidden">
-              <p class="text-[12px] sm:text-[14px] truncate max-w-[160px] sm:max-w-[200px]"><%= post.user.name %></p>
+              <p class="text-[12px] sm:text-[14px] truncate max-w-[160px] sm:max-w-[200px]"><%= post.user.nickname %></p>
               <p class="text-xs text-subtleText pl-0.5"><%= post.created_at.strftime("%Y/%m/%d") %></p>
             </div>
           </div>

--- a/app/views/posts/_search_form.html.erb
+++ b/app/views/posts/_search_form.html.erb
@@ -4,7 +4,7 @@
     <div class="grid grid-cols-3 sm:grid-cols-4 gap-1 sm:gap-2">
       <!-- キーワード検索 -->
       <div class="col-span-2 sm:col-span-3">
-        <%= f.search_field :body_or_shop_name_or_shop_address_or_user_name_cont, 
+        <%= f.search_field :body_or_shop_name_or_shop_address_or_user_nickname_or_user_username_cont, 
             class: 'input input-bordered w-full text-xs sm:text-sm bg-white placeholder:text-placeholder', 
             placeholder: t('defaults.search_word'),
             data: { search_clear_target: "input" } %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -20,7 +20,7 @@
           <% end %>
         </div>
         <div class="flex flex-col justify-center">
-          <p class="text-[12px] sm:text-[14px] truncate max-w-[120px] sm:max-w-[200px]"><%= @post.user.name %></p>
+          <p class="text-[12px] sm:text-[14px] truncate max-w-[120px] sm:max-w-[200px]"><%= @post.user.nickname %></p>
           <p class="text-xs sm:text-sm text-subtleText whitespace-nowrap pl-0.5"><%= @post.created_at.strftime("%Y/%m/%d %H:%M") %></p>
         </div>
       </div>

--- a/config/locales/devise.views.ja.yml
+++ b/config/locales/devise.views.ja.yml
@@ -25,9 +25,10 @@ ja:
         unconfirmed_email: 未確認Eメール
         unlock_token: ロック解除用トークン
         updated_at: 更新日
-        name: ユーザー名
+        username: ユーザー名
+        nickname: 名前
         avatar: プロフィール画像
-        comment: コメント
+        comment: 自己紹介
         preferred_sweetness: 甘さの好み
         preferred_firmness: 固さの好み
     models:

--- a/db/migrate/20241111083456_rename_name_to_nickname_and_add_username_to_users.rb
+++ b/db/migrate/20241111083456_rename_name_to_nickname_and_add_username_to_users.rb
@@ -1,0 +1,29 @@
+class RenameNameToNicknameAndAddUsernameToUsers < ActiveRecord::Migration[7.2]
+  def change
+    # 既存のnameカラムをnicknameにリネーム
+    rename_column :users, :name, :nickname
+
+    # usernameカラムを追加（NULLを許可）
+    add_column :users, :username, :string, null: true
+
+    # usernameカラムにユニークインデックスを追加
+    add_index :users, :username, unique: true
+
+    reversible do |dir|
+      dir.up do
+        User.reset_column_information # カラムの変更を反映
+        User.find_each do |user|
+          user.update(username: user.email.split('@').first) # メールアドレスの@より前をusernameに設定
+        end
+
+        # usernameカラムにNOT NULL制約を追加
+        change_column_null :users, :username, false
+      end
+
+      dir.down do
+        # 元に戻す処理
+        remove_column :users, :username
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_11_10_044703) do
+ActiveRecord::Schema[7.2].define(version: 2024_11_11_083456) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -82,7 +82,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_10_044703) do
   end
 
   create_table "users", force: :cascade do |t|
-    t.string "name", null: false
+    t.string "nickname", null: false
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
     t.string "reset_password_token"
@@ -93,9 +93,11 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_10_044703) do
     t.text "comment"
     t.integer "preferred_sweetness"
     t.integer "preferred_firmness"
+    t.string "username", null: false
     t.index ["email"], name: "index_users_on_email", unique: true
-    t.index ["name"], name: "index_users_on_name"
+    t.index ["nickname"], name: "index_users_on_nickname"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+    t.index ["username"], name: "index_users_on_username", unique: true
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"


### PR DESCRIPTION
## 変更内容

- アカウント登録時にusernameを作成し、編集でnicknameを修正できるように変更。
- nameカラムをnicknameカラムに変更し、既存のデータはメールアドレスの@以前の値となるようにマイグレーションの記述を変更
- 既存のビューのuserをnicknameに変更
- コントローラーのストロングパラメータを修正
- 新規登録時にnicknameはデフォルトでusernameと同じになるように実装
- ロケールファイルの修正

## 参考
https://www.notion.so/13b9ca21c80580a8be6fe18df4df75cb?pvs=4

## 関連ISSUE
- #220 