### PR TITLE
Feature/ユーザーページの作成

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -12,3 +12,4 @@ class UsersController < ApplicationController
       @posts = @user.posts.includes(:user).order(created_at: :desc)
     end
   end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,14 @@
+class UsersController < ApplicationController
+  before_action :authenticate_user!, only: [:show]
+
+  def show
+    @user = User.find_by(username: params[:username])
+    
+    if @user.nil?
+      redirect_to root_path, alert: "ユーザーが見つかりませんでした。"
+    elsif @user == current_user
+      redirect_to mypage_mypage_path
+    else
+      @posts = @user.posts.includes(:user).order(created_at: :desc)
+    end
+  end

--- a/app/views/mypage/shared/_profile.html.erb
+++ b/app/views/mypage/shared/_profile.html.erb
@@ -16,7 +16,7 @@
     <div class="flex items-center mt-1 sm:mt-2 space-x-1 sm:space-x-2 relative">
       <h2 class="text-[14px] sm:text-lg font-bold truncate max-w-[120px] sm:max-w-[200px]"><%= user.nickname %></h2>
       <% if user == current_user %>
-        <%= link_to edit_user_registration_path, class: "text-accent hover:text-hover z-[10]" do %>
+        <%= link_to edit_user_registration_path, class: "text-accent hover:text-hover z-[8]" do %>
           <i class="fas fa-pen text-xs sm:text-sm"></i>
         <% end %>
       <% end %>

--- a/app/views/mypage/shared/_profile.html.erb
+++ b/app/views/mypage/shared/_profile.html.erb
@@ -15,8 +15,10 @@
     <!-- ユーザー名と編集 -->
     <div class="flex items-center mt-1 sm:mt-2 space-x-1 sm:space-x-2 relative">
       <h2 class="text-[14px] sm:text-lg font-bold truncate max-w-[120px] sm:max-w-[200px]"><%= user.nickname %></h2>
-      <%= link_to edit_user_registration_path, class: "text-accent hover:text-hover z-[10]" do %>
-        <i class="fas fa-pen text-xs sm:text-sm"></i>
+      <% if user == current_user %>
+        <%= link_to edit_user_registration_path, class: "text-accent hover:text-hover z-[10]" do %>
+          <i class="fas fa-pen text-xs sm:text-sm"></i>
+        <% end %>
       <% end %>
     </div>
   </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,0 +1,16 @@
+<% content_for(:title, "#{@user.username}") %>
+<div class="min-h-screen mb-6 sm:mb-0">
+  <%= render 'mypage/shared/profile', user: @user %>
+  <div class="pb-4 max-w-sm sm:max-w-2xl mx-auto px-8 sm:px-4">
+    <hr class="border-none h-[1px] sm:h-0.5 bg-placeholder" />
+  </div>
+  <div class="container mx-auto px-8 sm:px-4 max-w-4xl">
+    <div class="space-y-4 mt-4">
+      <% if @posts.present? %>
+        <%= render partial: 'posts/post', collection: @posts %>
+      <% else %>
+        <div class='text-[12px] md:text-[14px] text-center'><%= t('.no_posts') %></div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -40,6 +40,9 @@ ja:
     login: ログイン
     logout: ログアウト
     my_page: マイページ
+  users:
+    show:
+      no_posts: 投稿はありません
   posts:
     new:
       title: プリン投稿作成

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,6 +35,8 @@ Rails.application.routes.draw do
     resources :bookmark_posts, only: [:index]
   end
 
+  get ':username', to: 'users#show', as: :user_profile
+
   resources :bookmarks, only: %i[create destroy]
 
 end


### PR DESCRIPTION
## 概要
**ユーザーページの作成**

- `/username`でユーザーページに遷移できるようにする
- 自分自身の場合`mypage`に遷移するようにコントローラーに記述
- ユーザーページにはプロフィールとユーザーの投稿一覧を表示
- 自分以外のプロフィールは編集できないようにする
- ログインしていないユーザーは遷移できないように設定
- 存在しないユーザーのページに遷移しようとした際、「ユーザーが見つかりませんでした」のエラーメッセージを表示


## 変更内容

- ルーティングの記述
- users_controller.rbの作成と記述
- users/show.html.erbの作成と記述
- _profile.html.erbの編集アイコン部分にif文を追加
- ja.ymlの追記



## 確認項目

- [x] - /usernameでそのユーザーのページに遷移できることを確認
- [x] - usernameがcurrent_userと一致する場合mypageに遷移することを確認
- [x] - ログインしていないとユーザーページに遷移できないことを確認
- [x] - current_userの場合のみ編集アイコンが表示されることを確認
- [x] - 存在しないusernameのURLに遷移しようとするとエラーメッセージが表示されることを確認

## その他
編集アイコンがヘッダーより上に表示されていたため、z-indexを修正

## 参考
https://www.notion.so/13b9ca21c80580a7be42ed4adef18f2d?pvs=4

## 関連ISSUE
- #218 