### PR TITLE
fix:usernameに.が含まれる場合のルーティングエラーを解消

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,7 +35,7 @@ Rails.application.routes.draw do
     resources :bookmark_posts, only: [:index]
   end
 
-  get ':username', to: 'users#show', as: :user_profile
+  get ':username', to: 'users#show', as: :user_profile, constraints: { username: /[^\/]+/ }
 
   resources :bookmarks, only: %i[create destroy]
 


### PR DESCRIPTION
## 変更内容
usernameに「.」が含めれる場合、/usernameでユーザーページに遷移しようとするとルーティングエラーが生じていたバグを解消

routes.rbでスラッシュ以外の文字を許可する記述
`get ':username', to: 'users#show', as: :user_profile, constraints: { username: /[^\/]+/ }`
これにより、スラッシュ（/）以外の任意の文字を含むユーザー名が許可され、（.）を含むユーザー名が正しく処理されるようになる。

## 確認項目
.を含むusernameのユーザーページに遷移できることを確認

## 参考
https://www.notion.so/13b9ca21c80580a7be42ed4adef18f2d?pvs=4

## 関連ISSUE
- #218 