### PR TITLE
fix:マイページタブのイベント修正

### DIFF
--- a/app/javascript/controllers/tab_controller.js
+++ b/app/javascript/controllers/tab_controller.js
@@ -5,6 +5,7 @@ export default class extends Controller {
 
   connect() {
     this.updateActiveTab()
+    document.addEventListener('turbo:load', this.updateActiveTab.bind(this))
   }
 
   updateActiveTab() {


### PR DESCRIPTION
## 概要
`tab_controller.js`内の`updateActiveTab`メソッドが
投稿一覧・詳細のアバターやニックネームからマイページに遷移した際に適用されない問題を修正

## 変更内容
`tab_controller.js`に`turbo:load`イベントリスナーを追加し、Turbo Driveによるすべての画面遷移後にタブの色を更新できるように修正

## 参考
https://www.notion.so/d77152702d134b0c9663841055d49a47?pvs=4

## 関連ISSUE
- #225 