### PR TITLE
fix:投稿削除できないバグを修正

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -4,7 +4,7 @@ class Post < ApplicationRecord
   belongs_to :user
   belongs_to :shop, optional: true
   has_many :bookmarks, dependent: :destroy
-  has_many :likes
+  has_many :likes, dependent: :destroy
   has_many :liked_users, through: :likes, source: :user
   has_one_attached :image
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,7 +17,7 @@ class User < ApplicationRecord
   has_many :posts
   has_many :bookmarks, dependent: :destroy
   has_many :bookmark_posts, through: :bookmarks, source: :post
-  has_many :likes
+  has_many :likes, dependent: :destroy
   has_many :liked_posts, through: :likes, source: :post
   has_one_attached :avatar
 


### PR DESCRIPTION
## 概要
投稿削除時に、`ActiveRecord::InvalidForeignKey`エラーが発生していた不具合を修正

## 変更内容
投稿を削除する前に、その投稿に関連する「いいね」を削除するように依存関係を追記

## 関連ISSUE
- #201 
- #232 