### PR TITLE
Fix/like responsive design

### DIFF
--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -1,6 +1,6 @@
 <%= turbo_frame_tag dom_id(post) do %>
   <div class="card bg-white shadow-lg mb-6 mx-auto flex-shrink px-0 max-w-sm sm:max-w-2xl relative">
-    <!-- 編集・削除ボタン -->
+    <!-- 編集・削除ボタン/ブックマーク -->
     <% if user_signed_in? && current_user.own?(post) %>
       <div class="absolute top-6 right-6 flex space-x-2 z-[5]">
         <%= link_to edit_post_path(post), class: "text-accent hover:text-hover", id: "button-edit-#{post.id}", data: { turbo_frame: "_top" } do %>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:title, "プリン一覧") %>
-<div class="container mx-auto px-8 sm:px-2 mt-2 sm:mt-4 max-w-4xl">
+<div class="container mx-auto px-6 sm:px-2 mt-2 sm:mt-4 max-w-4xl">
   <!-- 検索フォーム -->
   <%= render 'search_form', q: @q %>
 


### PR DESCRIPTION
## 変更内容

- スマホでの投稿一覧画面の左右余白調整

## その他
スマホ画面では詳細画面と同じブックマーク、いいねボタン配置にするため
hiddenクラスを使用しスマホ用とPC用で記述をしたところ、
turboのID重複によりいいねとブックマークのバリデーションエラーが発生したため、
一覧画面でのデザイン修正は行なっていません。
今後必要であれば再度検討します。

## 関連ISSUE
- #233 