### PR TITLE
Feature:いいねしたユーザー一覧をモーダルで表示

### DIFF
--- a/app/controllers/likes_controller.rb
+++ b/app/controllers/likes_controller.rb
@@ -4,10 +4,16 @@ class LikesController < ApplicationController
   def create
     @post = Post.find(params[:post_id])
     current_user.like(@post)
+    respond_to do |format|
+      format.turbo_stream
+    end
   end
 
   def destroy
     @post = current_user.likes.find(params[:id]).post
     current_user.unlike(@post)
+    respond_to do |format|
+      format.turbo_stream
+    end
   end
 end

--- a/app/views/likes/create.turbo_stream.erb
+++ b/app/views/likes/create.turbo_stream.erb
@@ -4,3 +4,6 @@
 <%= turbo_stream.update "like-count-#{@post.id}" do %>
   <%= @post.likes.count %>
 <% end %>
+<%= turbo_stream.update "liked-users-list-#{@post.id}" do %>
+  <%= render 'posts/liked_users', post: @post %>
+<% end %>

--- a/app/views/likes/destroy.turbo_stream.erb
+++ b/app/views/likes/destroy.turbo_stream.erb
@@ -4,3 +4,6 @@
 <%= turbo_stream.update "like-count-#{@post.id}" do %>
   <%= @post.likes.count %>
 <% end %>
+<%= turbo_stream.update "liked-users-list-#{@post.id}" do %>
+  <%= render 'posts/liked_users', post: @post %>
+<% end %>

--- a/app/views/posts/_like_modal.html.erb
+++ b/app/views/posts/_like_modal.html.erb
@@ -1,0 +1,16 @@
+<dialog id="like_modal_<%= post.id %>" class="modal">
+  <div class="modal-box">
+    <h3 class="font-bold text-lg">いいねしたユーザー</h3>
+    <div id="liked-users-list-<%= post.id %>">
+      <%= render 'posts/liked_users', post: post %>
+    </div>
+    <div class="modal-action">
+      <form method="dialog">
+        <button class="btn">閉じる</button>
+      </form>
+    </div>
+  </div>
+  <form method="dialog" class="modal-backdrop">
+    <button>close</button>
+  </form>
+</dialog>

--- a/app/views/posts/_like_modal.html.erb
+++ b/app/views/posts/_like_modal.html.erb
@@ -1,12 +1,11 @@
 <dialog id="like_modal_<%= post.id %>" class="modal">
-  <div class="modal-box">
-    <h3 class="font-bold text-lg">いいねしたユーザー</h3>
+  <div class="modal-box bg-white">
     <div id="liked-users-list-<%= post.id %>">
       <%= render 'posts/liked_users', post: post %>
     </div>
     <div class="modal-action">
       <form method="dialog">
-        <button class="btn">閉じる</button>
+        <button class="btn btn-sm btn-circle btn-ghost absolute right-4 top-4">×</button>
       </form>
     </div>
   </div>

--- a/app/views/posts/_liked_users.html.erb
+++ b/app/views/posts/_liked_users.html.erb
@@ -16,6 +16,6 @@
       </div>
     <% end %>
   <% else %>
-    <p class="text-center text-gray-500 text-sm sm:text-[16px]">いいねしたユーザーはいません</p>
+    <p class="text-center text-gray-500 text-sm sm:text-[16px]"><%= t('.no_users') %></p>
   <% end %>
 </div>

--- a/app/views/posts/_liked_users.html.erb
+++ b/app/views/posts/_liked_users.html.erb
@@ -1,0 +1,16 @@
+<div class="space-y-4">
+  <% post.liked_users.order(created_at: :desc).each do |user| %>
+    <div class="flex items-center">
+      <div class="w-10 h-10 rounded-full overflow-hidden mr-2 flex-shrink-0">
+        <% if user.avatar.attached? %>
+          <%= link_to image_tag(user.avatar.variant(resize_to_fill: [40, 40]), class: "w-full h-full object-cover"), user_profile_path(user.username), data: { turbo_frame: "_top" } %>
+        <% else %>
+          <%= link_to image_tag("default_avatar.png", class: "w-full h-full object-cover"), user_profile_path(user.username), data: { turbo_frame: "_top" } %>
+        <% end %>
+      </div>
+      <div>
+        <%= link_to user.nickname, user_profile_path(user.username), class: "text-sm font-semibold", data: { turbo_frame: "_top" } %>
+      </div>
+    </div>
+  <% end %>
+</div>

--- a/app/views/posts/_liked_users.html.erb
+++ b/app/views/posts/_liked_users.html.erb
@@ -1,16 +1,21 @@
 <div class="space-y-4">
-  <% post.liked_users.order(created_at: :desc).each do |user| %>
-    <div class="flex items-center">
-      <div class="w-10 h-10 rounded-full overflow-hidden mr-2 flex-shrink-0">
-        <% if user.avatar.attached? %>
-          <%= link_to image_tag(user.avatar.variant(resize_to_fill: [40, 40]), class: "w-full h-full object-cover"), user_profile_path(user.username), data: { turbo_frame: "_top" } %>
-        <% else %>
-          <%= link_to image_tag("default_avatar.png", class: "w-full h-full object-cover"), user_profile_path(user.username), data: { turbo_frame: "_top" } %>
-        <% end %>
+  <% liked_users = post.liked_users.order(created_at: :desc) %>
+  <% if liked_users.any? %>
+    <% liked_users.each do |user| %>
+      <div class="flex items-center">
+        <div class="w-10 h-10 rounded-full overflow-hidden mr-2 flex-shrink-0">
+          <% if user.avatar.attached? %>
+            <%= link_to image_tag(user.avatar.variant(resize_to_fill: [50, 50]), class: "w-full h-full object-cover"), user_profile_path(user.username), data: { turbo_frame: "_top" } %>
+          <% else %>
+            <%= link_to image_tag("default_avatar.png", class: "w-full h-full object-cover"), user_profile_path(user.username), data: { turbo_frame: "_top" } %>
+          <% end %>
+        </div>
+        <div>
+          <%= link_to user.nickname, user_profile_path(user.username), class: "text-[12px] sm:text-sm font-semibold", data: { turbo_frame: "_top" } %>
+        </div>
       </div>
-      <div>
-        <%= link_to user.nickname, user_profile_path(user.username), class: "text-sm font-semibold", data: { turbo_frame: "_top" } %>
-      </div>
-    </div>
+    <% end %>
+  <% else %>
+    <p class="text-center text-gray-500 text-sm sm:text-[16px]">いいねしたユーザーはいません</p>
   <% end %>
 </div>

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -81,9 +81,10 @@
                 <div class="mr-1">
                   <%= render 'posts/like_buttons', { post: post } %>
                 </div>
-                <div class="text-xs text-gray-500 w-[2ch] text-left" id="like-count-<%= post.id %>">
+                <div class="text-xs text-gray-500 w-[2ch] text-left cursor-pointer hover:underline" onclick="like_modal_<%= post.id %>.showModal()" id="like-count-<%= post.id %>">
                   <%= post.likes.count %>
                 </div>
+                <%= render 'posts/like_modal', post: post %>
               </div>
             </div>
           <% else %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -10,7 +10,7 @@
 <div class="container mx-auto px-6 sm:px-4 py-6 sm:py-8 max-w-xl sm:max-w-3xl">
   <div class="bg-white shadow-lg rounded-lg overflow-hidden px-4 sm:px-10 py-4 sm:py-10">
     <!-- ユーザー情報とアクションボタン -->
-    <div class="p-2 sm:p-4 flex justify-between items-center mb-3 sm:mb-4">
+    <div class="sm:p-4 flex justify-between items-center mb-3 sm:mb-4">
       <div class="flex items-center">
         <div class="w-10 h-10 sm:w-12 sm:h-12 rounded-full overflow-hidden mr-2 flex-shrink-0">
           <% if @post.user.avatar.attached? %>
@@ -45,21 +45,22 @@
 
     <!-- 投稿画像 -->
     <% if @post.image.attached? %>
-      <div class="w-11/12 mx-auto aspect-square rounded-sm flex items-center justify-center mb-2 sm:mb-3 overflow-hidden">
+      <div class="sm:mx-6 mx-auto aspect-square rounded-sm flex items-center justify-center mb-2 sm:mb-3 overflow-hidden">
         <%= image_tag @post.image.variant(resize_to_fill: [1000, 1000], format: :webp), class: "w-full h-full object-cover" %>
       </div>
     <% end %>
 
     <!-- ブックマークといいね -->
     <% if user_signed_in? %>
-      <div class="flex justify-end mb-4 sm:mb-6 px-6">
+      <div class="flex justify-end mb-4 sm:mb-6 px-1 sm:px-6">
         <div class="flex items-center mr-1">
           <div class="mr-1">
             <%= render 'posts/like_buttons', { post: @post } %>
           </div>
-          <div class="text-xs text-gray-500 w-[2ch] text-left" id="like-count-<%= @post.id %>">
+          <div class="text-xs text-gray-500 w-[2ch] text-left cursor-pointer hover:underline" onclick="like_modal_<%= @post.id %>.showModal()" id="like-count-<%= @post.id %>">
             <%= @post.likes.count %>
           </div>
+          <%= render 'posts/like_modal', post: @post %>
         </div>
         <% if @post.user != current_user %>
           <div class="sm:mr-3">
@@ -84,7 +85,7 @@
     </div>
 
     <!-- 評価、甘さ、固さの表示 -->
-    <div class="bg-base-200 bg-opacity-60 rounded-sm mx-2 md:mx-6 p-4 sm:p-6 my-6">
+    <div class="bg-base-200 bg-opacity-60 rounded-sm md:mx-6 p-4 sm:p-6 my-6">
       <!-- 評価 -->
       <div class="mb-6 sm:mb-10">
         <h3 class="text-sm sm:text-[16px] text-subtleText font-semibold mb-3 ml-1 sm:ml-2"><%= t('activerecord.attributes.post.overall_rating') %></h3>
@@ -138,17 +139,17 @@
       </div>
     </div>
 
-    <hr class="my-4 mx-2 md:mx-6 border-placeholder">
+    <hr class="my-4 md:mx-6 border-placeholder">
 
     <!-- 住所 -->
     <% if @post.shop&.address.present? %>
-      <div class="px-4 sm:px-8 pb-4 text-sm sm:text-lg text-subtleText">
+      <div class="px-2 sm:px-8 pb-4 text-sm sm:text-lg text-subtleText">
         <i class="fas fa-map-marker-alt mr-2 text-accent"></i><%= @post.shop.address %>
       </div>
     <% end %>
 
     <!-- Xシェア -->
-    <div class="mt-4 sm:mt-6 mb-2 text-center">
+    <div class="mt-4 sm:mt-6 sm:mb-2 text-center">
       <% 
         base_url = post_url(@post)
         timestamp = Time.now.to_i

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -57,6 +57,8 @@ ja:
     shop_name_default: お店
     index:
       no_posts: 投稿はありません
+    liked_users:
+     no_users: いいねしたユーザーはいません
     search_form:
       sweetness: 甘さ
       firmness: 固さ


### PR DESCRIPTION
## 概要
1. モーダルの実装:DaisyUIのモーダルコンポーネントを使用し、Turbo Framesと組み合わせて実装。
2. いいねユーザー一覧の非同期更新:Turbo Streamsを使用して、いいねボタンがクリックされたときにモーダル内のユーザー一覧を更新。

## 変更内容

- daisyUIのモーダルコンポーネント実装
- いいね数にモーダル表示のリンクを追加
  - show.html.erb
  - _post.html.erb

- LikesControllerの更新
  - app/controllers/likes_controller.rb 

- Turbo Streamの更新
  - app/views/likes/create.turbo_stream.erb
  - app/views/likes/destroy.turbo_stream.erb

- モーダルと詳細ページのデザイン修正

- 日本語化

## 期待する動作
・投稿一覧と詳細ページ内のいいね数からいいねしたユーザー一覧のモーダルに遷移
・いいねが更新されたらいいねしたユーザーも同時に更新される

## 参考
https://www.notion.so/13f9ca21c80580eca9abd607c246a6ca?pvs=4

## 関連ISSUE
- #203 
- #240 