### PR TITLE
fix:Likesコントローラのコード修正

### DIFF
--- a/app/controllers/likes_controller.rb
+++ b/app/controllers/likes_controller.rb
@@ -4,16 +4,10 @@ class LikesController < ApplicationController
   def create
     @post = Post.find(params[:post_id])
     current_user.like(@post)
-    respond_to do |format|
-      format.turbo_stream
-    end
   end
 
   def destroy
     @post = current_user.likes.find(params[:id]).post
     current_user.unlike(@post)
-    respond_to do |format|
-      format.turbo_stream
-    end
   end
 end


### PR DESCRIPTION
## 概要
省略可能な記述を削除

## 変更内容
Rails 7以降ではTurbo Streamのレスポンスがデフォルトで有効になっているため、以下の記述を削除しました。
```
    respond_to do |format|
      format.turbo_stream
    end
```

## 関連ISSUE
- #203 
- #240 