### PR TITLE
fix:メール内のリンク修正

### DIFF
--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -1,4 +1,4 @@
 <p><%= @resource.nickname %>様</p>
 <p>パスワード再発行のご依頼を受け付けました。</p>
 <p>以下のリンクからパスワードの再発行手続きを行ってください。</p>
-<p><%= link_to 'パスワードを再発行する', edit_password_url(@resource, reset_password_token: @token) %></p>
+<p style="margin: 0;"><%= link_to 'パスワードを再発行する', edit_password_url(@resource, reset_password_token: @token), style: "color: blue; text-decoration: underline;" %></p>


### PR DESCRIPTION
## 概要
スマホでメール内の「パスワードを再発行する」がリンクになっていない不具合の解消
メールクライアントによっては外部CSSや内部スタイルシートを無視することが原因と考え修正を行う

## 変更内容
リンクに対してインラインスタイルを使用して明示的に装飾

## 関連ISSUE
- #44 