### PR TITLE
Add/latitudeとlongitudeカラムの追加とgeocoderの導入

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,8 @@ gem 'ransack'
 gem "aws-sdk-s3", require: false
 gem 'dotenv-rails'
 
+gem 'geocoder'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem 'debug', platforms: %i[mri windows], require: 'debug/prelude'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -115,6 +115,7 @@ GEM
     crass (1.0.6)
     cssbundling-rails (1.4.1)
       railties (>= 6.0.0)
+    csv (3.3.0)
     date (3.3.4)
     debug (1.9.2)
       irb (~> 1.10)
@@ -139,6 +140,9 @@ GEM
     ffi (1.17.0-x86-linux-gnu)
     ffi (1.17.0-x86_64-darwin)
     ffi (1.17.0-x86_64-linux-gnu)
+    geocoder (1.8.3)
+      base64 (>= 0.1.0)
+      csv (>= 3.0.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
     i18n (1.14.6)
@@ -369,6 +373,7 @@ DEPENDENCIES
   devise
   devise-i18n
   dotenv-rails
+  geocoder
   image_processing (~> 1.2)
   jbuilder
   jsbundling-rails

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -10,6 +10,10 @@ class PostsController < ApplicationController
               .order(created_at: :desc)
   end
 
+  def map
+    @posts = Post.includes(:user, :shop).where.not(shops: { address: nil, latitude: nil, longitude: nil })
+  end
+
   def new
     @post = Post.new
     @post.build_shop  # 新しい店舗を作成するための空のオブジェクトを用意
@@ -94,8 +98,6 @@ class PostsController < ApplicationController
     @post = Post.find(params[:id])
     @liked_users = @post.liked_users.order(created_at: :desc)
   end
-
-  def map; end
 
   private
 

--- a/app/models/shop.rb
+++ b/app/models/shop.rb
@@ -4,9 +4,8 @@ class Shop < ApplicationRecord
   validates :name, presence: true, length: { maximum: 255 }
   validates :address, allow_blank: true, length: { maximum: 255 }
 
-  # 将来的に実装予定の機能のためのコメントアウト
-  # geocoded_by :address
-  # after_validation :geocode, if: :address_changed?
+  geocoded_by :address
+  after_validation :geocode, if: ->(obj){ obj.address.present? && obj.address_changed? }
 
   def self.ransackable_attributes(auth_object = nil)
     ["name", "address"]

--- a/app/views/posts/map.html.erb
+++ b/app/views/posts/map.html.erb
@@ -1,15 +1,33 @@
-<h2>Google Map Test</h2>
-<input id="address" type="textbox" value="">
-<input type="button" value="送信" onclick="codeAddress()">
-<input type="button" value="現在地を表示" onclick="showCurrentLocation()">
-<div id="latlngDisplay">ここに緯度、経緯が表示される</div>
-<div id="addressDisplay">ここに住所が表示される</div>
-<div id="map"></div>
+<div id="map-container">
+  <input id="address" type="textbox" value="">
+  <input type="button" value="送信" onclick="codeAddress()">
+  <input type="button" value="現在地を表示" onclick="showCurrentLocation()">
+  <div id="latlngDisplay">ここに緯度、経緯が表示される</div>
+  <div id="addressDisplay">ここに住所が表示される</div>
+  <div id="map"></div>
+</div>
 
 <style>
+html, body {
+  height: 100%;
+  margin: 0;
+  padding: 0;
+}
+
+#map-container {
+  height: 100vh;
+  width: 100vw;
+  display: flex;
+  flex-direction: column;
+}
+
 #map {
-    height: 600px;
-    width: 600px;
+  flex-grow: 1;
+  width: 100%;
+}
+
+#address, input[type="button"], #latlngDisplay, #addressDisplay {
+  margin: 10px;
 }
 </style>
 
@@ -20,16 +38,21 @@ const latlngDis = document.getElementById('latlngDisplay');
 const addressDis = document.getElementById('addressDisplay');
 
 function initMap() {
-    const geocoder = new google.maps.Geocoder();
+  const geocoder = new google.maps.Geocoder();
 
-    map = new google.maps.Map(document.getElementById('map'), {
-        zoom: 12,
-    });
+  map = new google.maps.Map(document.getElementById('map'), {
+    zoom: 12,
+  });
 
-    marker = new google.maps.Marker({
-        map: map,
-    });
-    showCurrentLocation();
+  marker = new google.maps.Marker({
+    map: map,
+  });
+  showCurrentLocation();
+
+  // ウィンドウサイズが変更されたときに地図のサイズを調整
+  google.maps.event.addDomListener(window, 'resize', function() {
+    google.maps.event.trigger(map, 'resize');
+  });
 }
 
 function codeAddress() {

--- a/config/initializers/geocoder.rb
+++ b/config/initializers/geocoder.rb
@@ -1,0 +1,27 @@
+Geocoder.configure(
+  # Geocoding options
+  # timeout: 3,                 # geocoding service timeout (secs)
+  lookup: :google,         # name of geocoding service (symbol)
+  # ip_lookup: :ipinfo_io,      # name of IP address geocoding service (symbol)
+  # language: :en,              # ISO-639 language code
+  use_https: true,           # use HTTPS for lookup requests? (if supported)
+  # http_proxy: nil,            # HTTP proxy server (user:pass@host:port)
+  # https_proxy: nil,           # HTTPS proxy server (user:pass@host:port)
+  api_key: ENV['GOOGLE_MAPS_API_KEY'],               # API key for geocoding service
+  # cache: nil,                 # cache object (must respond to #[], #[]=, and #del)
+
+  # Exceptions that should not be rescued by default
+  # (if you want to implement custom error handling);
+  # supports SocketError and Timeout::Error
+  # always_raise: [],
+
+  # Calculation options
+  # units: :mi,                 # :km for kilometers or :mi for miles
+  # distances: :linear          # :spherical or :linear
+
+  # Cache configuration
+  # cache_options: {
+  #   expiration: 2.days,
+  #   prefix: 'geocoder:'
+  # }
+)

--- a/db/migrate/20241120123610_add_latitude_and_longitude_to_shops.rb
+++ b/db/migrate/20241120123610_add_latitude_and_longitude_to_shops.rb
@@ -1,0 +1,15 @@
+class AddLatitudeAndLongitudeToShops < ActiveRecord::Migration[7.2]
+  def change
+    add_column :shops, :latitude, :float
+    add_column :shops, :longitude, :float
+    
+    reversible do |dir|
+      dir.up do
+        Shop.find_each do |shop|
+          shop.geocode
+          shop.save
+        end
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_11_13_142853) do
+ActiveRecord::Schema[7.2].define(version: 2024_11_20_123610) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -88,6 +88,8 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_13_142853) do
     t.string "address"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.float "latitude"
+    t.float "longitude"
     t.index ["name"], name: "index_shops_on_name"
   end
 


### PR DESCRIPTION
## 概要
geocoderを導入し住所を緯度と経度に変換
shopsテーブルにlatitudeとlongitudeカラムの追加

## 変更内容

- gem geocoderのインストール
- config/initializers/geocoder.rbを修正
- shopsテーブルにカラム追加
- 既存のデータ更新
- Shopモデルにgeocoderを設定
- PostsControllerのmapアクションを更新

## 参考
https://www.notion.so/geocoder-958a669f7a874bf09a0661cbbcda33b2?pvs=4

## 備忘
地図に投稿を表示する実装は別ISSUEにて行う
地図のレイアウトは今後調整予定

## 関連ISSUE
- #46 
- #47 
