### PR TITLE
投稿と現在地を異なるマーカーで表示

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -11,7 +11,7 @@ class PostsController < ApplicationController
   end
 
   def map
-    @posts = Post.includes(:user, :shop).where.not(shops: { address: nil, latitude: nil, longitude: nil })
+    @posts = Post.includes(:user, :shop).where.not(shops: { address: "", latitude: nil, longitude: nil })
   end
 
   def new

--- a/app/views/posts/map.html.erb
+++ b/app/views/posts/map.html.erb
@@ -1,41 +1,17 @@
-<div id="map-container">
-  <input id="address" type="textbox" value="">
-  <input type="button" value="送信" onclick="codeAddress()">
-  <input type="button" value="現在地を表示" onclick="showCurrentLocation()">
-  <div id="latlngDisplay">ここに緯度、経緯が表示される</div>
-  <div id="addressDisplay">ここに住所が表示される</div>
-  <div id="map"></div>
+<div id="map-container" class="h-screen w-screen flex flex-col">
+  <input id="address" type="textbox" value="" class="m-2.5">
+  <input type="button" value="送信" onclick="codeAddress()" class="m-2.5">
+  <input type="button" value="現在地を表示" onclick="showCurrentLocation()" class="m-2.5">
+  <div id="map" class="flex-grow w-full"></div>
 </div>
-
-<style>
-html, body {
-  height: 100%;
-  margin: 0;
-  padding: 0;
-}
-
-#map-container {
-  height: 100vh;
-  width: 100vw;
-  display: flex;
-  flex-direction: column;
-}
-
-#map {
-  flex-grow: 1;
-  width: 100%;
-}
-
-#address, input[type="button"], #latlngDisplay, #addressDisplay {
-  margin: 10px;
-}
-</style>
 
 <script>
 let map, marker;
 
 const latlngDis = document.getElementById('latlngDisplay');
 const addressDis = document.getElementById('addressDisplay');
+const iconImage = 'https://maps.google.com/mapfiles/ms/micons/yellow-dot.png';
+const currentLocation = 'https://www.google.com/mapfiles/marker.png';
 
 function initMap() {
   const geocoder = new google.maps.Geocoder();
@@ -44,17 +20,8 @@ function initMap() {
     zoom: 12,
   });
 
-  marker = new google.maps.Marker({
-    //position: { lat: 35.658581, lng: 139.745433 },
-    map: map,
-  });
   showCurrentLocation();
   setShopMarkers();
-
-  // ウィンドウサイズが変更されたときに地図のサイズを調整
-  google.maps.event.addDomListener(window, 'resize', function() {
-    google.maps.event.trigger(map, 'resize');
-  });
 }
 
 function setShopMarkers() {
@@ -62,7 +29,8 @@ function setShopMarkers() {
     new google.maps.Marker({
       position: {lat: <%= post.shop.latitude %>, lng: <%= post.shop.longitude %>}, 
       map: map,
-      title: '<%= j post.shop.name %>'
+      title: '<%= j post.shop.name %>',
+      icon: iconImage
     });
   <% end %>
 }
@@ -91,7 +59,16 @@ function showCurrentLocation(){
             lng: position.coords.longitude
         };
         map.setCenter(userLocation);
-        marker.setPosition(userLocation);
+        if (marker) {
+            marker.setMap(null);
+        }
+        
+        // 新しいマーカーを作成
+        marker = new google.maps.Marker({
+            position: userLocation,
+            map: map,
+            icon: currentLocation // 現在地用のアイコンを使用
+        });
         latlngDis.innerHTML = `Latitude: ${userLocation.lat}, Longitude: ${userLocation.lng}`;
         }, function() {
         alert('位置情報の取得に失敗しました。');

--- a/app/views/posts/map.html.erb
+++ b/app/views/posts/map.html.erb
@@ -45,14 +45,26 @@ function initMap() {
   });
 
   marker = new google.maps.Marker({
+    //position: { lat: 35.658581, lng: 139.745433 },
     map: map,
   });
   showCurrentLocation();
+  setShopMarkers();
 
   // ウィンドウサイズが変更されたときに地図のサイズを調整
   google.maps.event.addDomListener(window, 'resize', function() {
     google.maps.event.trigger(map, 'resize');
   });
+}
+
+function setShopMarkers() {
+  <% @posts.each do |post| %>
+    new google.maps.Marker({
+      position: {lat: <%= post.shop.latitude %>, lng: <%= post.shop.longitude %>}, 
+      map: map,
+      title: '<%= j post.shop.name %>'
+    });
+  <% end %>
 }
 
 function codeAddress() {


### PR DESCRIPTION
## 変更内容

- スタイルをtailwindCSSの書き方に修正
- `setShopMarkers`関数で投稿をピンで表示
- 現在地と投稿用のピンをそれぞれ定義し、`setShopMarkers`と`showCurrentLocation`関数内でmarkerを作成し使用
- 関数内でmarkerを作成しているため、`initMap`内の`marker = new google.maps.Marker`は削除
- mapアクションの修正
　┗住所がないものはaddressカラムがnilではなく空文字で保存されているため、`posts_controller`のmapアクションを修正

## 備忘
今後検索機能実装時に、`codeAddress`関数は削除予定

## 参考
https://www.notion.so/14b9ca21c805807c8c1ae99063315453?pvs=4

## 関連ISSUE
- #47 
- #52 
- #53 
- #54