### PR TITLE
Add:マップにモーダルを追加

### DIFF
--- a/app/views/posts/map.html.erb
+++ b/app/views/posts/map.html.erb
@@ -6,7 +6,7 @@
 </div>
 
 <dialog id="post_modal" class="modal">
-    <div class="modal-box">
+    <div class="modal-box bg-white">
         <div class="post_show"></div>
     </div>
 </dialog>
@@ -49,13 +49,76 @@ function setShopMarkers() {
 
       shopMarker.addListener('click', function() {
         const modalContent = `
-          <h3 class="font-bold text-lg"><%= j post.shop.name %></h3>
-          <p><%= j post.body %></p>
-          <div class="modal-action">
-            <form method="dialog">
-              <button class="btn">閉じる</button>
-            </form>
+        <% if user_signed_in? %>
+          <div class="flex justify-end mb-2">
+            <div class="flex items-center mr-1">
+              <div class="mr-1">
+                <%= render 'posts/like_buttons', { post: post } %>
+              </div>
+              <div class="text-xs text-gray-500 w-[2ch] text-left cursor-pointer hover:underline" onclick="like_modal_<%= post.id %>.showModal()" id="like-count-<%= post.id %>">
+                <%= post.likes.count %>
+              </div>
+              <%= render 'posts/like_modal', post: post %>
+            </div>
+            <% if post.user != current_user %>
+              <div class="sm:mr-3">
+                <%= render 'bookmark_buttons', { post: post } %>
+              </div>
+            <% end %>
           </div>
+        <% else %>
+          <div class="flex items-center justify-end mb-2">
+            <div class="text-sweetDeep mr-1">
+              <i class="far fa-heart text-[18px] sm:text-[20px]"></i>
+            </div>
+            <div class="text-xs text-gray-500 w-[2ch] text-left" id="like-count-<%= post.id %>">
+              <%= post.likes.count %>
+            </div>
+          </div>
+        <% end %>
+        <div class='text-center'>
+          <div class='text-xs sm:text-[12px] text-subtleText'><%= t("enums.post.category.#{post.category}") %></div>
+          <div class='text-lg sm:text-[18px] font-semibold'><%= post.shop.name %></div>
+        </div>
+        <div class='flex justify-center'>
+          <% if post.image.present? %>
+            <%= image_tag post.image, class: 'object-contain w-60 h-60 mt-3' %>
+          <% else %>
+          <% end %>
+        </div>
+        <div class='flex flex-col items-center justify-center mt-4'>
+          <div class="mb-4 flex justify-center space-x-1">
+            <% Post.overall_ratings.size.times do |i| %>
+              <span 
+                class="inline-block w-6 h-6 sm:w-7 sm:h-7 mask mask-star-2 <%= i < Post.overall_ratings[post.overall_rating] ? 'bg-accent' : 'bg-placeholder' %>"
+                aria-hidden="true"
+              ></span>
+            <% end %>
+          </div>
+          <div class="flex flex-wrap items-center mb-3 text-sm sm:text-[18px] text-center sm:text-left">
+            <div class="flex items-center">
+              <div class="tooltip" data-tip="<%= t("tooltips.sweetness", percentage: post.sweetness_percentage) %>">
+                <span class="badge text-xs sm:text-sm py-2 sm:py-2.5 <%= sweetness_badge_color(post.sweetness) %> mr-0.5 sm:mr-1"><%= t("enums.post.sweetness.#{post.sweetness}") %></span>
+              </div>
+            </div>
+            <div class="flex items-center">
+              <div class="tooltip" data-tip="<%= t("tooltips.firmness", percentage: post.firmness_percentage) %>">
+                <span class="badge text-xs sm:text-sm py-2 sm:py-2.5 <%= firmness_badge_color(post.firmness) %>"><%= t("enums.post.firmness.#{post.firmness}") %></span>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="flex items-center justify-center">
+          <div class="text-left max-w-md mx-4 sm:mx-6">
+            <p class="my-2 text-sm sm:text-[16px] text-subtleText">
+              <i class="fa fa-map-marker-alt mr-2 text-accent"></i><%= post.shop.address %>
+            </p>
+            <p><%= simple_format(truncate(post.body, length: 50, omission: '...'), class: "text-sm sm:text-[16px] break-words text-text text-opacity-80") %></p>
+          </div>
+        </div>
+        <div class='text-right mt-3 mr-1'>
+          <%= link_to "詳細", post_path(post), class: "text-accent underline" %>
+        </div>
         `;
         document.querySelector('.post_show').innerHTML = modalContent;
         document.getElementById('post_modal').showModal();

--- a/app/views/posts/map.html.erb
+++ b/app/views/posts/map.html.erb
@@ -117,7 +117,7 @@ function setShopMarkers() {
           </div>
         </div>
         <div class='text-right mt-3 mr-1'>
-          <%= link_to "詳細", post_path(post), class: "text-accent underline" %>
+          <%= link_to "詳細", post_path(post), class: "text-[12px] sm:text-[14px] text-accent underline" %>
         </div>
         `;
         document.querySelector('.post_show').innerHTML = modalContent;

--- a/app/views/posts/map.html.erb
+++ b/app/views/posts/map.html.erb
@@ -5,6 +5,12 @@
   <div id="map" class="flex-grow w-full"></div>
 </div>
 
+<dialog id="post_modal" class="modal">
+    <div class="modal-box">
+        <div class="post_show"></div>
+    </div>
+</dialog>
+
 <script>
 let map, marker;
 
@@ -22,16 +28,39 @@ function initMap() {
 
   showCurrentLocation();
   setShopMarkers();
+
+  document.addEventListener('click', function(event) {
+    const modal = document.getElementById('post_modal');
+    if (event.target === modal) {
+      modal.close();
+    }
+  });
 }
 
 function setShopMarkers() {
   <% @posts.each do |post| %>
-    new google.maps.Marker({
-      position: {lat: <%= post.shop.latitude %>, lng: <%= post.shop.longitude %>}, 
-      map: map,
-      title: '<%= j post.shop.name %>',
-      icon: iconImage
-    });
+    (() => {
+      let shopMarker = new google.maps.Marker({
+        position: {lat: <%= post.shop.latitude %>, lng: <%= post.shop.longitude %>}, 
+        map: map,
+        title: '<%= j post.shop.name %>',
+        icon: iconImage
+      });
+
+      shopMarker.addListener('click', function() {
+        const modalContent = `
+          <h3 class="font-bold text-lg"><%= j post.shop.name %></h3>
+          <p><%= j post.body %></p>
+          <div class="modal-action">
+            <form method="dialog">
+              <button class="btn">閉じる</button>
+            </form>
+          </div>
+        `;
+        document.querySelector('.post_show').innerHTML = modalContent;
+        document.getElementById('post_modal').showModal();
+      });
+    })();
   <% end %>
 }
 


### PR DESCRIPTION
## 変更内容
- daisyUIのモーダルコンポーネントを使用し投稿をモーダルで表示

## テストした動作
- [x] マーカーをクリックすると投稿詳細のモーダルが表示されること
- [x] ログインしているユーザーはいいね、ブックマークが可能
- [x] モーダルから詳細ページに遷移できること
- [x] モーダル以外の箇所をクリックするとモーダル画面が閉じること

## 備忘
**以下調整が必要**
- 投稿作成後マップページに遷移した際、リロードしないとマーカーが表示されない
- ログインした状態でマップ画面を表示した後ログアウトした際、リロードしないとログインしている人用のモーダルが表示されてしまう

## 参考
https://www.notion.so/Map-547e3ce4efb14337a1fccf2789e0fe2b?pvs=4

## 関連ISSUE
- #55 