### PR TITLE
fix:マップモーダル内のいいねアイコンの青枠が表示されないように修正

### DIFF
--- a/app/views/posts/_to_like.html.erb
+++ b/app/views/posts/_to_like.html.erb
@@ -1,3 +1,3 @@
-<%= link_to post_likes_path(post_id: post.id), id: "like-button-for-post-#{post.id}", data: { turbo_method: :post }, class: "text-sweetDeep" do %>
+<%= link_to post_likes_path(post_id: post.id), id: "like-button-for-post-#{post.id}", data: { turbo_method: :post }, class: "text-sweetDeep focus:outline-none focus-visible:outline-none" do %>
   <i class="far fa-heart text-[18px] sm:text-[20px]"></i>
 <% end %>

--- a/app/views/posts/_to_unlike.html.erb
+++ b/app/views/posts/_to_unlike.html.erb
@@ -1,3 +1,3 @@
-<%= link_to post_like_path(post_id: post.id, id: current_user.likes.find_by(post_id: post.id).id), id: "unlike-button-for-post-#{post.id}", data: { turbo_method: :delete }, class: "text-sweetDeep" do %>
+<%= link_to post_like_path(post_id: post.id, id: current_user.likes.find_by(post_id: post.id).id), id: "unlike-button-for-post-#{post.id}", data: { turbo_method: :delete }, class: "text-sweetDeep focus:outline-none focus-visible:outline-none" do %>
   <i class="fas fa-heart text-[18px] sm:text-[20px]"></i>
 <% end %>


### PR DESCRIPTION
## 変更内容
safariのみマップモーダル内のいいねが青枠で囲われていた不具合を修正
いいねのビューに以下クラスを追記
`focus:outline-none focus-visible:outline-none`

## 関連ISSUE
- #259 

## 参考
https://www.notion.so/css-focus-visible-1439ca21c8058082a423e15433ef9df2?pvs=4