### PR TITLE
Fix/show header

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -56,4 +56,8 @@
     border: 4px solid #A67C5B; /* Thumb border color */
     cursor: pointer;
   }
+
+  .menu-item-custom {
+    @apply hover:bg-accent hover:text-white active:bg-accent active:text-white focus:bg-accent focus:text-white !important;
+  }
 }

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -38,7 +38,7 @@
     </div>
 
     <!-- カテゴリー -->
-    <h2 class="text-sm md:text-[16px] text-text text-opacity-70 mt-8 sm:mt-10 mb-1 sm:mb-2 text-center"><%= t("enums.post.category.#{@post.category}") %></h2>
+    <h2 class="text-sm md:text-[16px] text-subtleText mt-8 sm:mt-10 mb-1 sm:mb-2 text-center"><%= t("enums.post.category.#{@post.category}") %></h2>
 
     <!-- 店舗名 -->
     <h1 class="text-2xl md:text-3xl font-bold mb-8 sm:mb-10 text-center"><%= @post.shop.name %></h1>
@@ -80,8 +80,10 @@
     <% end %>
 
     <!-- コメント -->
-    <div class="px-6 md:px-12 lg:px-16 pb-4">
-      <%= simple_format(@post.body, class: "text-sm sm:text-lg text-left break-words text-text text-opacity-80") %>
+    <div class="px-6 md:px-12 lg:px-16 pb-4 flex justify-center">
+      <div class="max-w-full">
+        <%= simple_format(@post.body, class: "text-sm sm:text-lg text-left break-words text-text text-opacity-80 inline-block") %>
+      </div>
     </div>
 
     <!-- 評価、甘さ、固さの表示 -->

--- a/app/views/shared/_before_login_header.erb
+++ b/app/views/shared/_before_login_header.erb
@@ -19,16 +19,16 @@
   <div class="drawer-side z-50">
     <label for="my-drawer-4" class="drawer-overlay z-40"></label>
     <ul class="menu bg-base bg-opacity-90 text-base-content min-h-full w-60 sm:w-80 p-4 z-50">
-      <li><%= link_to t('header.login'), new_user_session_path, class: "hover:bg-accent hover:text-white" %></li>
-      <li><%= link_to t('header.sign_up'), new_user_registration_path, class: "hover:bg-accent hover:text-white" %></li>
-      <li><%= link_to t('header.how_to'), root_path, class: "hover:bg-accent hover:text-white" %></li>
+      <li><%= link_to t('header.login'), new_user_session_path, class: "menu-item-custom !bg-transparent" %></li>
+      <li><%= link_to t('header.sign_up'), new_user_registration_path, class: "menu-item-custom !bg-transparent" %></li>
+      <li><%= link_to t('header.how_to'), root_path, class: "menu-item-custom !bg-transparent" %></li>
       <div class="divider divider-default"></div>
-      <li><%= link_to t('header.maps_path'), maps_path, data: { turbo: false }, class: "hover:bg-accent hover:text-white" %></li>
-      <li><%= link_to t('header.posts_path'), posts_path, class: "hover:bg-accent hover:text-white" %></li>
+      <li><%= link_to t('header.maps_path'), maps_path, data: { turbo: false }, class: "menu-item-custom !bg-transparent" %></li>
+      <li><%= link_to t('header.posts_path'), posts_path, class: "menu-item-custom !bg-transparent" %></li>
       <div class="divider divider-default"></div>
-      <li><%= link_to t('header.terms_of_service_path'), terms_of_service_path, class: "hover:bg-accent hover:text-white" %></li>
-      <li><%= link_to t('header.privacy_policy_path'), privacy_policy_path, class: "hover:bg-accent hover:text-white" %></li>
-      <li><%= link_to t('header.contact_path'), contact_path, class: "hover:bg-accent hover:text-white" %></li>
+      <li><%= link_to t('header.terms_of_service_path'), terms_of_service_path, class: "menu-item-custom !bg-transparent" %></li>
+      <li><%= link_to t('header.privacy_policy_path'), privacy_policy_path, class: "menu-item-custom !bg-transparent" %></li>
+      <li><%= link_to t('header.contact_path'), contact_path, class: "menu-item-custom !bg-transparent" %></li>
       <div class="divider divider-default"></div>
       <div class="text-center text-sm py-2">
         © 2024 - PurinMania

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -20,7 +20,7 @@
     <label for="my-drawer-4" class="drawer-overlay z-40"></label>
     <ul class="menu bg-base bg-opacity-90 text-[12px] sm:text-[14px] min-h-full w-60 sm:w-80 p-4 z-50">
       <li class="mb-2">
-        <%= link_to mypage_mypage_path, class: "flex items-center sm:ml-2 mt-2 sm:p-2 hover:bg-transparent" do %>
+        <%= link_to mypage_mypage_path, class: "flex items-center sm:ml-2 mt-2 sm:p-2 hover:bg-transparent focus:bg-transparent focus:text-text !bg-transparent !text-text" do %>
           <div class="w-10 h-10 sm:w-12 sm:h-12 rounded-full overflow-hidden mr-1 sm:mr-2 flex-shrink-0">
             <% if current_user.avatar.attached? %>
               <%= image_tag(current_user.avatar.variant(resize_to_fill: [200, 200]), class: "w-full h-full object-cover") %>
@@ -34,17 +34,17 @@
         <% end %>
       </li>
       <div class="divider divider-default my-2"></div>
-      <li><%= link_to t('header.my_page'), mypage_mypage_path, class: "hover:bg-accent hover:text-white" %></li>
-      <li><%= link_to t('header.logout'), destroy_user_session_path, data: { turbo_method: :delete }, class: "hover:bg-accent hover:text-white" %></li>
-      <li><%= link_to t('header.how_to'), root_path, class: "hover:bg-accent hover:text-white" %></li>
+      <li><%= link_to t('header.my_page'), mypage_mypage_path, class: "menu-item-custom !bg-transparent" %></li>
+      <li><%= link_to t('header.logout'), destroy_user_session_path, data: { turbo_method: :delete }, class: "menu-item-custom !bg-transparent" %></li>
+      <li><%= link_to t('header.how_to'), root_path, class: "menu-item-custom !bg-transparent" %></li>
       <div class="divider divider-default"></div>
-      <li><%= link_to t('header.maps_path'), maps_path, data: { turbo: false }, class: "hover:bg-accent hover:text-white" %></li>
-      <li><%= link_to t('header.posts_path'), posts_path, class: "hover:bg-accent hover:text-white" %></li>
-      <li><%= link_to t('header.new_post_path'), new_post_path, class: "hover:bg-accent hover:text-white" %></li>
+      <li><%= link_to t('header.maps_path'), maps_path, data: { turbo: false }, class: "menu-item-custom !bg-transparent" %></li>
+      <li><%= link_to t('header.posts_path'), posts_path, class: "menu-item-custom !bg-transparent" %></li>
+      <li><%= link_to t('header.new_post_path'), new_post_path, class: "menu-item-custom !bg-transparent" %></li>
       <div class="divider divider-default"></div>
-      <li><%= link_to t('header.terms_of_service_path'), terms_of_service_path, class: "hover:bg-accent hover:text-white" %></li>
-      <li><%= link_to t('header.privacy_policy_path'), privacy_policy_path, class: "hover:bg-accent hover:text-white" %></li>
-      <li><%= link_to t('header.contact_path'), contact_path, class: "hover:bg-accent hover:text-white" %></li>
+      <li><%= link_to t('header.terms_of_service_path'), terms_of_service_path, class: "menu-item-custom !bg-transparent" %></li>
+      <li><%= link_to t('header.privacy_policy_path'), privacy_policy_path, class: "menu-item-custom !bg-transparent" %></li>
+      <li><%= link_to t('header.contact_path'), contact_path, class: "menu-item-custom !bg-transparent" %></li>
       <div class="divider divider-default"></div>
       <div class="text-center text-sm py-2">
         © 2024 - PurinMania

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -18,7 +18,22 @@
   </div>
   <div class="drawer-side z-50">
     <label for="my-drawer-4" class="drawer-overlay z-40"></label>
-    <ul class="menu bg-base bg-opacity-90 text-base-content min-h-full w-60 sm:w-80 p-4 z-50">
+    <ul class="menu bg-base bg-opacity-90 text-[12px] sm:text-[14px] min-h-full w-60 sm:w-80 p-4 z-50">
+      <li class="mb-2">
+        <%= link_to mypage_mypage_path, class: "flex items-center sm:ml-2 mt-2 sm:p-2 hover:bg-transparent" do %>
+          <div class="w-10 h-10 sm:w-12 sm:h-12 rounded-full overflow-hidden mr-1 sm:mr-2 flex-shrink-0">
+            <% if current_user.avatar.attached? %>
+              <%= image_tag(current_user.avatar.variant(resize_to_fill: [200, 200]), class: "w-full h-full object-cover") %>
+            <% else %>
+              <%= image_tag("default_avatar.png", class: "w-full h-full object-cover") %>
+            <% end %>
+          </div>
+          <div class="flex flex-col justify-center overflow-hidden">
+            <span class="font-medium truncate max-w-[160px] sm:max-w-[200px]"><%= current_user.nickname %></span>
+          </div>
+        <% end %>
+      </li>
+      <div class="divider divider-default my-2"></div>
       <li><%= link_to t('header.my_page'), mypage_mypage_path, class: "hover:bg-accent hover:text-white" %></li>
       <li><%= link_to t('header.logout'), destroy_user_session_path, data: { turbo_method: :delete }, class: "hover:bg-accent hover:text-white" %></li>
       <li><%= link_to t('header.how_to'), root_path, class: "hover:bg-accent hover:text-white" %></li>


### PR DESCRIPTION
## 変更内容

- 詳細ページの修正
　┗コメントのレイアウト修正/カテゴリーのテキストカラー修正
- ヘッダー修正
　┗ログイン後ヘッダーにアイコンとユーザー名を表示し、遷移先をマイページに設定
　┗daisyUIのmenuクラスのデフォルトデザインの無効化

## 参考
https://www.notion.so/869bfae1e9c74cc3b0e884549063c14b?pvs=4

## 関連ISSUE
- #266 

