### PR TITLE
Feature:詳細ページに地図を表示

### DIFF
--- a/app/views/maps/index.html.erb
+++ b/app/views/maps/index.html.erb
@@ -120,7 +120,7 @@ function setShopMarkers() {
           </div>
         </div>
         <div class='text-right mt-1 mr-1'>
-          <%= link_to "詳細", post_path(post), class: "text-[12px] sm:text-[14px] text-accent underline focus:outline-none focus-visible:outline-none" %>
+          <%= link_to "詳細", post_path(post), data: { turbo: false }, class: "text-[12px] sm:text-[14px] text-accent underline focus:outline-none focus-visible:outline-none" %>
         </div>
         `;
         document.querySelector('.post_show').innerHTML = modalContent;

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -37,16 +37,16 @@
           <!-- 画像ー -->
           <div class="aspect-square overflow-hidden pt-4">
             <% if post.image.attached? %>
-              <%= link_to image_tag(post.image.variant(resize_to_fill: [800, 800], format: :webp), class: "w-full h-full object-cover"), post_path(post), data: { turbo_frame: "_top" } %>
+              <%= link_to image_tag(post.image.variant(resize_to_fill: [800, 800], format: :webp), class: "w-full h-full object-cover"), post_path(post), data: { turbo: false } %>
             <% else %>
-              <%= link_to image_tag("default_image.png", class: "w-full h-full object-cover"), post_path(post), data: { turbo_frame: "_top" }  %>
+              <%= link_to image_tag("default_image.png", class: "w-full h-full object-cover"), post_path(post), data: { turbo: false } %>
             <% end %>
           </div>
         </div>
         <div class="w-full sm:w-3/5 px-4 pt-4">
           <h2 class="text-xs md:text-sm text-subtleText mt-2 mb-1 text-center sm:text-left"><%= t("enums.post.category.#{post.category}") %></h2>
           <h1 class="text-xl sm:text-2xl font-bold mb-3 text-center sm:text-left">
-            <%= link_to post.shop.name, post_path(post), data: { turbo_frame: "_top" } %>
+            <%= link_to post.shop.name, post_path(post), data: { turbo: false } %>
           </h1>
           <div class="flex justify-center sm:justify-start mb-4 space-x-1">
             <% Post.overall_ratings.size.times do |i| %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -141,15 +141,14 @@
       </div>
     </div>
 
-    <!-- マップ -->
-    <div class="mt-6 relative">
-      <div id="map" style="height: 400px; width: 100%;"></div>
-    </div>
-
-    <!-- 住所 -->
+    <!-- マップと住所 -->
     <% if @post.shop&.address.present? %>
-      <div class="px-2 sm:px-8 pb-4 text-sm sm:text-lg text-subtleText">
-        <i class="fas fa-map-marker-alt mr-2 text-accent"></i><%= @post.shop.address %>
+      <div class="mt-6 relative">
+        <div id="map" style="height: 400px; width: 100%;"></div>
+        <!-- 住所 -->
+        <div class="px-2 sm:px-8 pb-4 text-sm sm:text-lg text-subtleText">
+          <i class="fas fa-map-marker-alt mr-2 text-accent"></i><%= @post.shop.address %>
+        </div>
       </div>
     <% end %>
 

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -7,10 +7,10 @@
   ) %>
 <% end %>
 
-<div class="container mx-auto px-6 sm:px-4 py-6 sm:py-8 max-w-xl sm:max-w-3xl">
-  <div class="bg-white shadow-lg rounded-lg overflow-hidden px-4 sm:px-10 py-4 sm:py-10">
+<div class="container mx-auto sm:py-8 max-w-xl sm:max-w-3xl">
+  <div class="bg-white sm:shadow-lg sm:rounded-lg overflow-hidden py-4">
     <!-- ユーザー情報とアクションボタン -->
-    <div class="sm:p-4 flex justify-between items-center mb-3 sm:mb-4">
+    <div class="py-3 px-3 sm:py-4 sm:px-8 flex justify-between items-center mb-3 sm:mb-4">
       <div class="flex items-center">
         <div class="w-10 h-10 sm:w-12 sm:h-12 rounded-full overflow-hidden mr-2 flex-shrink-0">
           <% if @post.user.avatar.attached? %>
@@ -26,19 +26,19 @@
       </div>
       <!-- 編集・削除ボタン -->
       <% if user_signed_in? && current_user.own?(@post) %>
-        <div class="flex space-x-2">
+        <div class="flex space-x-3">
           <%= link_to edit_post_path(@post), class: "text-accent hover:text-hover", id: "button-edit-#{@post.id}", data: { turbo_frame: "_top" } do %>
             <i class="fas fa-edit text-[18px] sm:text-[20px]"></i>
           <% end %>
           <%= link_to post_path(@post), class: "text-accent hover:text-hover", id: "button-delete-#{@post.id}", data: { turbo_method: :delete, turbo_confirm: t('defaults.delete_confirm'),turbo_frame: "_top" } do %>
-            <i class="fas fa-trash text-[18px] sm:text-[20px]"></i>
+            <i class="fas fa-trash text-[18px] sm:text-[20px] mr-2"></i>
           <% end %>
         </div>
       <% end %>
     </div>
 
     <!-- カテゴリー -->
-    <h2 class="text-sm md:text-[16px] text-subtleText mt-8 sm:mt-10 mb-1 sm:mb-2 text-center"><%= t("enums.post.category.#{@post.category}") %></h2>
+    <h2 class="text-sm md:text-[16px] text-subtleText mt-8 mb-1 sm:mb-2 text-center"><%= t("enums.post.category.#{@post.category}") %></h2>
 
     <!-- 店舗名 -->
     <h1 class="text-2xl md:text-3xl font-bold mb-8 sm:mb-10 text-center"><%= @post.shop.name %></h1>
@@ -87,10 +87,10 @@
     </div>
 
     <!-- 評価、甘さ、固さの表示 -->
-    <div class="bg-base-200 bg-opacity-60 rounded-sm md:mx-6 p-4 sm:p-6 my-6">
+    <div class="p-4 sm:p-6 my-6">
       <!-- 評価 -->
       <div class="mb-6 sm:mb-10">
-        <h3 class="text-sm sm:text-[16px] text-subtleText font-semibold mb-3 ml-1 sm:ml-2"><%= t('activerecord.attributes.post.overall_rating') %></h3>
+        <h3 class="text-sm sm:text-[16px] text-subtleText font-semibold mb-3 ml-4 sm:ml-4"><%= t('activerecord.attributes.post.overall_rating') %>:</h3>
         <div class="flex justify-center">
           <% Post.overall_ratings.size.times do |i| %>
             <span 
@@ -141,7 +141,10 @@
       </div>
     </div>
 
-    <hr class="my-4 md:mx-6 border-placeholder">
+    <!-- マップ -->
+    <div class="mt-6 relative">
+      <div id="map" style="height: 400px; width: 100%;"></div>
+    </div>
 
     <!-- 住所 -->
     <% if @post.shop&.address.present? %>
@@ -151,7 +154,7 @@
     <% end %>
 
     <!-- Xシェア -->
-    <div class="mt-4 sm:mt-6 sm:mb-2 text-center">
+    <div class="my-4 sm:my-6 sm:mb-2 text-center">
       <% 
         base_url = post_url(@post)
         timestamp = Time.now.to_i
@@ -165,3 +168,26 @@
     </div>
   </div>
 </div>
+
+<script>
+  let map, marker;
+
+  const iconImage = 'https://maps.google.com/mapfiles/ms/micons/yellow-dot.png';
+
+  function initMap() {
+    const shopLocation = {lat: <%= @post.shop.latitude %>, lng: <%= @post.shop.longitude %>};
+  
+    map = new google.maps.Map(document.getElementById('map'), {
+      zoom: 12,
+      center: shopLocation
+    });
+
+    marker = new google.maps.Marker({
+      position: shopLocation,
+      map: map,
+      title: '<%= j @post.shop.name %>',
+      icon: iconImage
+    });
+  }
+</script>
+<script src="https://maps.googleapis.com/maps/api/js?key=<%= ENV["GOOGLE_MAPS_API_KEY"] %>&callback=initMap" data-turbo-track="reload"></script>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -146,8 +146,18 @@
       <div class="mt-6 relative">
         <div id="map" style="height: 400px; width: 100%;"></div>
         <!-- 住所 -->
-        <div class="px-2 sm:px-8 pb-4 text-sm sm:text-lg text-subtleText">
-          <i class="fas fa-map-marker-alt mr-2 text-accent"></i><%= @post.shop.address %>
+        <div class="hidden sm:block absolute top-16 left-2 right-0 bg-white bg-opacity-90 py-4 px-6 w-1/3">
+          <div class="font-bold text-[18px] mb-1">
+            <%= @post.shop.name %>
+          </div>
+          <p class="text-[15px]"><%= @post.shop.address %></p>
+        </div>
+        <!-- スマートフォン用の住所表示 -->
+        <div class="sm:hidden py-4 px-6">
+          <div class="font-bold text-[15px] mb-0.5">
+            <%= @post.shop.name %>
+          </div>
+          <p class="text-[12px]"><%= @post.shop.address %></p>
         </div>
       </div>
     <% end %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -187,7 +187,7 @@
     const shopLocation = {lat: <%= @post.shop.latitude %>, lng: <%= @post.shop.longitude %>};
   
     map = new google.maps.Map(document.getElementById('map'), {
-      zoom: 12,
+      zoom: 16,
       center: shopLocation
     });
 


### PR DESCRIPTION
## 変更内容
- 詳細ページに地図を表示
- 詳細ページへのリンクでturboを無効化
　┗リロードしないと元の地図を維持してしまう事象を解消
- 詳細ページのレイアウト修正
　┗スマホでは周りの余白を削除
- 住所をレスポンシブに表示
　┗スマホ：地図の下　スマホ以外：地図内

## 参考
https://www.notion.so/1529ca21c80580a39756e9c30fc4c705?pvs=4

## 備忘
経路やGoogolemapへの動線は未実装

## 関連ISSUE
- #48 
