### PR TITLE
Fix:詳細ページのレイアウト修正

### DIFF
--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -52,7 +52,7 @@
 
     <!-- ブックマークといいね -->
     <% if user_signed_in? %>
-      <div class="flex justify-end mb-4 sm:mb-6 px-1 sm:px-6">
+      <div class="flex justify-end mb-4 sm:mb-6 px-3 sm:px-6">
         <div class="flex items-center mr-1">
           <div class="mr-1">
             <%= render 'posts/like_buttons', { post: @post } %>
@@ -63,7 +63,7 @@
           <%= render 'posts/like_modal', post: @post %>
         </div>
         <% if @post.user != current_user %>
-          <div class="sm:mr-3">
+          <div class="mr-3">
             <%= render 'bookmark_buttons', { post: @post } %>
           </div>
         <% end %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -38,10 +38,10 @@
     </div>
 
     <!-- カテゴリー -->
-    <h2 class="text-sm md:text-[16px] text-subtleText mt-8 mb-1 sm:mb-2 text-center"><%= t("enums.post.category.#{@post.category}") %></h2>
+    <h2 class="text-[12px] md:text-[14px] text-subtleText mt-2 mb-1 sm:mb-2 text-center"><%= t("enums.post.category.#{@post.category}") %></h2>
 
     <!-- 店舗名 -->
-    <h1 class="text-2xl md:text-3xl font-bold mb-8 sm:mb-10 text-center"><%= @post.shop.name %></h1>
+    <h1 class="text-xl md:text-[26px] font-bold mb-2 sm:mb-6 text-center"><%= @post.shop.name %></h1>
 
     <!-- 投稿画像 -->
     <% if @post.image.attached? %>
@@ -52,7 +52,7 @@
 
     <!-- ブックマークといいね -->
     <% if user_signed_in? %>
-      <div class="flex justify-end mb-4 sm:mb-6 px-3 sm:px-6">
+      <div class="flex justify-end mb-2 sm:mb-4 px-4 sm:px-6">
         <div class="flex items-center mr-1">
           <div class="mr-1">
             <%= render 'posts/like_buttons', { post: @post } %>
@@ -69,7 +69,7 @@
         <% end %>
       </div>
     <% else %>
-      <div class="flex items-center justify-end mb-4 sm:mb-6 px-6">
+      <div class="flex items-center justify-end mb-2 sm:mb-4 px-6">
         <div class="text-sweetDeep mr-1">
           <i class="far fa-heart text-[18px] sm:text-[20px]"></i>
         </div>
@@ -80,14 +80,14 @@
     <% end %>
 
     <!-- コメント -->
-    <div class="px-6 md:px-12 lg:px-16 pb-4 flex justify-center">
+    <div class="px-6 md:px-12 lg:px-16 pb-2 flex justify-center">
       <div class="max-w-full">
-        <%= simple_format(@post.body, class: "text-sm sm:text-lg text-left break-words text-text text-opacity-80 inline-block") %>
+        <%= simple_format(@post.body, class: "text-sm sm:text-[16px] text-left break-words text-text text-opacity-80 inline-block") %>
       </div>
     </div>
 
     <!-- 評価、甘さ、固さの表示 -->
-    <div class="p-4 sm:p-6 my-6">
+    <div class="p-4 sm:p-6">
       <!-- 評価 -->
       <div class="mb-6 sm:mb-10">
         <h3 class="text-sm sm:text-[16px] text-subtleText font-semibold mb-3 ml-4 sm:ml-4"><%= t('activerecord.attributes.post.overall_rating') %>:</h3>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -46,7 +46,7 @@
     <!-- 投稿画像 -->
     <% if @post.image.attached? %>
       <div class="sm:mx-6 mx-auto aspect-square rounded-sm flex items-center justify-center mb-2 sm:mb-3 overflow-hidden">
-        <%= image_tag @post.image.variant(resize_to_fill: [1000, 1000], format: :webp), class: "w-full h-full object-cover" %>
+        <%= image_tag @post.image.variant(resize_to_fill: [1200, 1200], format: :webp), class: "w-full h-full object-cover" %>
       </div>
     <% end %>
 


### PR DESCRIPTION
## 変更内容

- スマホ画面でのブックマークといいねボタンの余白を修正
- 店名の上下余白を調整
- 画像の画質を調整
- フォントの大きさを調整
- ページ内の余白調整

## 関連ISSUE
- #48 
- #270 