### PR TITLE
Fix:詳細ページと投稿作成ページの修正

### DIFF
--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -119,6 +119,13 @@
         fields: ['name', 'formatted_address', 'geometry']
       });
     autocomplete.addListener('place_changed', onPlaceChanged);
+    // キーボードイベントリスナーを追加
+    document.getElementById('autocomplete').addEventListener('keydown', function(event) {
+      if (event.key === 'Enter') {
+        event.preventDefault(); // デフォルトのフォーム送信を防ぐ
+        onPlaceChanged(); // 手動でonPlaceChangedを呼び出す
+      }
+    });
   }
 
   function onPlaceChanged() {

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -3,7 +3,7 @@
     <!-- 編集・削除ボタン/ブックマーク -->
     <% if user_signed_in? && current_user.own?(post) %>
       <div class="absolute top-6 right-6 flex space-x-2 z-[5]">
-        <%= link_to edit_post_path(post), class: "text-accent hover:text-hover", id: "button-edit-#{post.id}", data: { turbo_frame: "_top" } do %>
+        <%= link_to edit_post_path(post), class: "text-accent hover:text-hover", id: "button-edit-#{post.id}", data: { turbo: false } do %>
           <i class="fas fa-edit text-[18px] sm:text-[20px]"></i>
         <% end %>
         <%= link_to post_path(post), class: "text-accent hover:text-hover", id: "button-delete-#{post.id}", data: { turbo_method: :delete, turbo_confirm: t('defaults.delete_confirm') } do %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -146,7 +146,7 @@
       <div class="mt-6 relative">
         <div id="map" style="height: 400px; width: 100%;"></div>
         <!-- 住所 -->
-        <div class="hidden sm:block absolute top-16 left-2 right-0 bg-white bg-opacity-90 py-4 px-6 w-1/3">
+        <div class="hidden sm:block absolute top-4 left-4 right-0 bg-white bg-opacity-90 py-4 px-6 w-1/3">
           <div class="font-bold text-[18px] mb-1">
             <%= @post.shop.name %>
           </div>
@@ -179,24 +179,40 @@
 </div>
 
 <script>
-  let map, marker;
-
-  const iconImage = 'https://maps.google.com/mapfiles/ms/micons/yellow-dot.png';
-
   function initMap() {
-    const shopLocation = {lat: <%= @post.shop.latitude %>, lng: <%= @post.shop.longitude %>};
-  
-    map = new google.maps.Map(document.getElementById('map'), {
-      zoom: 16,
-      center: shopLocation
+  const mapElement = document.getElementById('map');
+  const mapOptions = {
+    center: { lat: <%= @post.shop.latitude %>, lng: <%= @post.shop.longitude %> },
+    zoom: 16,
+    disableDefaultUI: true,
+  };
+  const googleMapUrl = `
+    <a href="https://www.google.com/maps/search/?api=1&query=<%= @post.shop.latitude %>,<%= @post.shop.longitude %>"
+    class="font-medium text-blue-600 dark:text-blue-500 hover:underline">
+    Googleマップで見る</a>`
+  const infowindow = new google.maps.InfoWindow({
+    content: googleMapUrl,
+  });
+  const map = new google.maps.Map(mapElement, mapOptions);
+  const marker = new google.maps.Marker({
+    position: { lat: <%= @post.shop.latitude %>, lng: <%= @post.shop.longitude %> },
+    map: map,
+  });
+  marker.addListener("click", () => {
+    infowindow.open({
+    anchor: marker,
+    map,
     });
-
-    marker = new google.maps.Marker({
-      position: shopLocation,
-      map: map,
-      title: '<%= j @post.shop.name %>',
-      icon: iconImage
-    });
+  });
   }
+  document.addEventListener('turbo:load', function() {
+    const link = document.getElementById('link');
+    link.addEventListener('click', function() {
+    const postUrl = encodeURIComponent("<%= post_url(@post) %>");
+    const restaurantName = encodeURIComponent("<%= @post.shop.name %>");
+    const tweetText = `【ひとり外食投稿アプリ】%0aMeTimeMealsで${restaurantName}をチェック！%23Me_Time_Meals`;
+    window.open(`https://twitter.com/intent/tweet?url=${postUrl}&text=${tweetText}`, '_blank');
+    });
+  });
 </script>
-<script src="https://maps.googleapis.com/maps/api/js?key=<%= ENV["GOOGLE_MAPS_API_KEY"] %>&callback=initMap" data-turbo-track="reload"></script>
+<script async defer src="https://maps.googleapis.com/maps/api/js?key=<%= ENV['GOOGLE_MAPS_API_KEY'] %>&callback=initMap"></script>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -27,7 +27,7 @@
       <!-- 編集・削除ボタン -->
       <% if user_signed_in? && current_user.own?(@post) %>
         <div class="flex space-x-3">
-          <%= link_to edit_post_path(@post), class: "text-accent hover:text-hover", id: "button-edit-#{@post.id}", data: { turbo_frame: "_top" } do %>
+          <%= link_to edit_post_path(@post), class: "text-accent hover:text-hover", id: "button-edit-#{@post.id}", data: { turbo: false } do %>
             <i class="fas fa-edit text-[18px] sm:text-[20px]"></i>
           <% end %>
           <%= link_to post_path(@post), class: "text-accent hover:text-hover", id: "button-delete-#{@post.id}", data: { turbo_method: :delete, turbo_confirm: t('defaults.delete_confirm'),turbo_frame: "_top" } do %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -180,39 +180,17 @@
 
 <script>
   function initMap() {
-  const mapElement = document.getElementById('map');
-  const mapOptions = {
-    center: { lat: <%= @post.shop.latitude %>, lng: <%= @post.shop.longitude %> },
-    zoom: 16,
-    disableDefaultUI: true,
-  };
-  const googleMapUrl = `
-    <a href="https://www.google.com/maps/search/?api=1&query=<%= @post.shop.latitude %>,<%= @post.shop.longitude %>"
-    class="font-medium text-blue-600 dark:text-blue-500 hover:underline">
-    Googleマップで見る</a>`
-  const infowindow = new google.maps.InfoWindow({
-    content: googleMapUrl,
-  });
-  const map = new google.maps.Map(mapElement, mapOptions);
-  const marker = new google.maps.Marker({
-    position: { lat: <%= @post.shop.latitude %>, lng: <%= @post.shop.longitude %> },
-    map: map,
-  });
-  marker.addListener("click", () => {
-    infowindow.open({
-    anchor: marker,
-    map,
+    const mapElement = document.getElementById('map');
+    const mapOptions = {
+      center: { lat: <%= @post.shop.latitude %>, lng: <%= @post.shop.longitude %> },
+      zoom: 16,
+      disableDefaultUI: true,
+    };
+    const map = new google.maps.Map(mapElement, mapOptions);
+    const marker = new google.maps.Marker({
+      position: { lat: <%= @post.shop.latitude %>, lng: <%= @post.shop.longitude %> },
+      map: map,
     });
-  });
   }
-  document.addEventListener('turbo:load', function() {
-    const link = document.getElementById('link');
-    link.addEventListener('click', function() {
-    const postUrl = encodeURIComponent("<%= post_url(@post) %>");
-    const restaurantName = encodeURIComponent("<%= @post.shop.name %>");
-    const tweetText = `【ひとり外食投稿アプリ】%0aMeTimeMealsで${restaurantName}をチェック！%23Me_Time_Meals`;
-    window.open(`https://twitter.com/intent/tweet?url=${postUrl}&text=${tweetText}`, '_blank');
-    });
-  });
 </script>
 <script async defer src="https://maps.googleapis.com/maps/api/js?key=<%= ENV['GOOGLE_MAPS_API_KEY'] %>&callback=initMap"></script>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -21,7 +21,7 @@
     <span class="text-[8px] sm:text-[10px]"><%= t('footer.posts_path') %></span>
   <% end %>
 
-  <%= link_to new_post_path, class: "group bg-main text-accent flex flex-col items-center justify-center" do %>
+  <%= link_to new_post_path, data: { turbo: false }, class: "group bg-main text-accent flex flex-col items-center justify-center" do %>
     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6 group-hover:hidden">
       <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v6m3-3H9m12 0a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
     </svg>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -40,7 +40,7 @@
       <div class="divider divider-default"></div>
       <li><%= link_to t('header.maps_path'), maps_path, data: { turbo: false }, class: "menu-item-custom !bg-transparent" %></li>
       <li><%= link_to t('header.posts_path'), posts_path, class: "menu-item-custom !bg-transparent" %></li>
-      <li><%= link_to t('header.new_post_path'), new_post_path, class: "menu-item-custom !bg-transparent" %></li>
+      <li><%= link_to t('header.new_post_path'), new_post_path, data: { turbo: false }, class: "menu-item-custom !bg-transparent" %></li>
       <div class="divider divider-default"></div>
       <li><%= link_to t('header.terms_of_service_path'), terms_of_service_path, class: "menu-item-custom !bg-transparent" %></li>
       <li><%= link_to t('header.privacy_policy_path'), privacy_policy_path, class: "menu-item-custom !bg-transparent" %></li>


### PR DESCRIPTION
## 変更内容
**詳細ページの不具合修正**
- 投稿作成・編集後に詳細ページに遷移した際、最新の地図が反映されていない不具合を修正
　┗`show.html.erb`の`initMap`関数を修正

**投稿作成ページの不具合修正**
- 投稿作成フォーム内で店名入力時にエンターを押した際、店名に住所と店名が入り、住所が空のまま自動で作成されてしまう不具合を修正
　┗キーボードイベントを追記し、enterを押した際のフォーム送信を無効化し、`onPlaceChanged`が呼び出されるように修正
- 投稿作成ページ/投稿編集ページに遷移した際、カテゴリーが選択された状態になっている不具合を修正
　┗遷移時にturboを無効化

## 参考
https://www.notion.so/1589ca21c80580079d71c263c0f35d0f?pvs=4

## 関連ISSUE
- #48 
- #276 
- #204 
- #56 