### PR TITLE
Feature:Googlemapの経路/情報ページのリンク作成

### DIFF
--- a/app/views/maps/index.html.erb
+++ b/app/views/maps/index.html.erb
@@ -171,7 +171,7 @@ function setShopMarkers() {
         <div class='text-center mt-1 sm:mt-2 flex justify-center space-x-1 text-sm'>
           <%= link_to "詳細ページ", post_path(post), data: { turbo: false }, class: "text-accent hover:text-accent/80 hover:underline" %>
           <span class="text-gray-500">/</span>
-          <%= link_to "経路を調べる", "https://www.google.com/maps/dir/?api=1&destination=#{post.shop.latitude},#{post.shop.longitude}", target: :_blank, class: "text-accent hover:text-accent/80 hover:underline" %>
+          <%= link_to "経路を調べる", "https://www.google.com/maps/dir/?api=1&destination=#{CGI.escape(post.shop.name + ' ' + post.shop.address)}", target: :_blank, class: "text-accent hover:text-accent/80 hover:underline" %>
         </div>
         `;
         document.querySelector('.post_show').innerHTML = modalContent;

--- a/app/views/maps/index.html.erb
+++ b/app/views/maps/index.html.erb
@@ -168,8 +168,10 @@ function setShopMarkers() {
             </div>
           </div>
         </div>
-        <div class='text-right mt-1 mr-1'>
-          <%= link_to "詳細", post_path(post), data: { turbo: false }, class: "text-[12px] sm:text-[14px] text-accent underline focus:outline-none focus-visible:outline-none" %>
+        <div class='text-center mt-1 sm:mt-2 flex justify-center space-x-1 text-sm'>
+          <%= link_to "詳細ページ", post_path(post), data: { turbo: false }, class: "text-accent hover:text-accent/80 hover:underline" %>
+          <span class="text-gray-500">/</span>
+          <%= link_to "経路を調べる", "https://www.google.com/maps/dir/?api=1&destination=#{post.shop.latitude},#{post.shop.longitude}", target: :_blank, class: "text-accent hover:text-accent/80 hover:underline" %>
         </div>
         `;
         document.querySelector('.post_show').innerHTML = modalContent;

--- a/app/views/maps/index.html.erb
+++ b/app/views/maps/index.html.erb
@@ -169,9 +169,9 @@ function setShopMarkers() {
           </div>
         </div>
         <div class='text-center mt-1 sm:mt-2 flex justify-center space-x-1 text-sm'>
-          <%= link_to "詳細ページ", post_path(post), data: { turbo: false }, class: "text-accent hover:text-accent/80 hover:underline" %>
+          <%= link_to t('.to_show'), post_path(post), data: { turbo: false }, class: "text-accent hover:text-accent/80 hover:underline" %>
           <span class="text-gray-500">/</span>
-          <%= link_to "経路を調べる", "https://www.google.com/maps/dir/?api=1&destination=#{CGI.escape(post.shop.name + ' ' + post.shop.address)}", target: :_blank, class: "text-accent hover:text-accent/80 hover:underline" %>
+          <%= link_to t('.to_route'), "https://www.google.com/maps/dir/?api=1&destination=#{CGI.escape(post.shop.name + ' ' + post.shop.address)}", target: :_blank, class: "text-accent hover:text-accent/80 hover:underline" %>
         </div>
         `;
         document.querySelector('.post_show').innerHTML = modalContent;

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -151,6 +151,9 @@
             <%= @post.shop.name %>
           </div>
           <p class="text-[15px]"><%= @post.shop.address %></p>
+          <div class="mt-2 w-full">
+            <%= link_to "Google mapで見る", "https://www.google.com/maps/search/?api=1&query=#{CGI.escape(@post.shop.name + ' ' + @post.shop.address)}", target: :_blank, class: "block w-full text-center text-[14px] py-2 px-4 border border-accent text-accent bg-white hover:bg-accent hover:text-white transition duration-300 ease-in-out rounded-sm" %>
+          </div>
         </div>
         <!-- スマートフォン用の住所表示 -->
         <div class="sm:hidden py-4 px-6">
@@ -158,6 +161,9 @@
             <%= @post.shop.name %>
           </div>
           <p class="text-[12px]"><%= @post.shop.address %></p>
+          <div class="mt-2 w-full">
+            <%= link_to "Google mapで見る", "https://www.google.com/maps/search/?api=1&query=#{CGI.escape(@post.shop.name + ' ' + @post.shop.address)}", target: :_blank, class: "block w-full text-center text-[12px] py-2 px-4 border border-accent text-accent bg-white hover:bg-accent hover:text-white transition duration-300 ease-in-out rounded-sm" %>
+          </div>
         </div>
       </div>
     <% end %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -152,7 +152,7 @@
           </div>
           <p class="text-[15px]"><%= @post.shop.address %></p>
           <div class="mt-2 w-full">
-            <%= link_to "Google mapで見る", "https://www.google.com/maps/search/?api=1&query=#{CGI.escape(@post.shop.name + ' ' + @post.shop.address)}", target: :_blank, class: "block w-full text-center text-[14px] py-2 px-4 border border-accent text-accent bg-white hover:bg-accent hover:text-white transition duration-300 ease-in-out rounded-sm" %>
+            <%= link_to t('.to_googlemap'), "https://www.google.com/maps/search/?api=1&query=#{CGI.escape(@post.shop.name + ' ' + @post.shop.address)}", target: :_blank, class: "block w-full text-center text-[14px] py-2 px-4 border border-accent text-accent bg-white hover:bg-accent hover:text-white transition duration-300 ease-in-out rounded-sm" %>
           </div>
         </div>
         <!-- スマートフォン用の住所表示 -->
@@ -162,7 +162,7 @@
           </div>
           <p class="text-[12px]"><%= @post.shop.address %></p>
           <div class="mt-2 w-full">
-            <%= link_to "Google mapで見る", "https://www.google.com/maps/search/?api=1&query=#{CGI.escape(@post.shop.name + ' ' + @post.shop.address)}", target: :_blank, class: "block w-full text-center text-[12px] py-2 px-4 border border-accent text-accent bg-white hover:bg-accent hover:text-white transition duration-300 ease-in-out rounded-sm" %>
+            <%= link_to t('.to_googlemap'), "https://www.google.com/maps/search/?api=1&query=#{CGI.escape(@post.shop.name + ' ' + @post.shop.address)}", target: :_blank, class: "block w-full text-center text-[12px] py-2 px-4 border border-accent text-accent bg-white hover:bg-accent hover:text-white transition duration-300 ease-in-out rounded-sm" %>
           </div>
         </div>
       </div>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -58,6 +58,8 @@ ja:
   maps:
     index:
       title: マップ検索
+      to_show: 詳細ページ
+      to_route: 経路を調べる
   posts:
     new:
       title: プリン投稿作成
@@ -65,6 +67,8 @@ ja:
       title: プリン一覧
     edit:
       title: プリン投稿編集
+    show:
+      to_googlemap: Google mapで見る
     form:
       shop_name_placeholder: お店の名前を入力してください
       shop_address_placeholder: お店の住所を入力してください


### PR DESCRIPTION
## 変更内容
- 地図検索ページのモーダル内にgooglemapの経路検索へのリンクを追加
- 詳細ページにgooglemapの情報ページへのリンクを追加

## 参考
https://www.notion.so/1609ca21c80580e694aadb1b9f705de4?pvs=4

## 関連ISSUE
- #241 
- #242 