### PR TITLE
fix:ページネーションをアイコンを用いて表示

### DIFF
--- a/app/views/kaminari/_first_page.html.erb
+++ b/app/views/kaminari/_first_page.html.erb
@@ -6,4 +6,7 @@
     per_page:      number of items to fetch per page
     remote:        data-remote
 -%>
-<%= link_to_unless current_page.first?, t('pagination.first').html_safe, url, class: "join-item btn btn-sm btn-ghost hover:bg-base-200 active:bg-transparent", remote: true %>
+<%= link_to_unless current_page.first?,
+  raw("<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='size-4' width='4'><path stroke-linecap='round' stroke-linejoin='round' d='m18.75 4.5-7.5 7.5 7.5 7.5m-6-15L5.25 12l7.5 7.5'/></svg>"), 
+  url,
+  class: "join-item btn btn-sm btn-ghost hover:bg-base-200 active:bg-transparent", remote: true %>

--- a/app/views/kaminari/_last_page.html.erb
+++ b/app/views/kaminari/_last_page.html.erb
@@ -6,4 +6,7 @@
     per_page:      number of items to fetch per page
     remote:        data-remote
 -%>
-<%= link_to_unless current_page.last?, t('pagination.last').html_safe, url, class: "join-item btn btn-sm btn-ghost hover:bg-base-200 active:bg-transparent", remote: true %>
+<%= link_to_unless current_page.last?,
+  raw("<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='size-4' width='4'><path stroke-linecap='round' stroke-linejoin='round' d='m5.25 4.5 7.5 7.5-7.5 7.5m6-15 7.5 7.5-7.5 7.5'/></svg>"), 
+  url,
+  class: "join-item btn btn-sm btn-ghost hover:bg-base-200 active:bg-transparent", remote: true %>

--- a/app/views/kaminari/_next_page.html.erb
+++ b/app/views/kaminari/_next_page.html.erb
@@ -6,4 +6,7 @@
     per_page:      number of items to fetch per page
     remote:        data-remote
 -%>
-<%= link_to_unless current_page.last?, t('pagination.next').html_safe, url, class: "join-item btn btn-sm btn-ghost hover:bg-base-200 active:bg-transparent", rel: 'next', remote: true %>
+<%= link_to_unless current_page.last?,
+  raw("<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='size-4' width='4'><path stroke-linecap='round' stroke-linejoin='round' d='m8.25 4.5 7.5 7.5-7.5 7.5'/></svg>"), 
+  url,
+  class: "join-item btn btn-sm btn-ghost hover:bg-base-200 active:bg-transparent", rel: 'next', remote: true %>

--- a/app/views/kaminari/_prev_page.html.erb
+++ b/app/views/kaminari/_prev_page.html.erb
@@ -6,4 +6,7 @@
     per_page:      number of items to fetch per page
     remote:        data-remote
 -%>
-<%= link_to_unless current_page.first?, t('pagination.previous').html_safe, url, class: "join-item btn btn-sm btn-ghost hover:bg-base-200 active:bg-transparent", rel: 'prev', remote: true %>
+<%= link_to_unless current_page.first?,
+  raw("<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='size-4' width='4'><path stroke-linecap='round' stroke-linejoin='round' d='M15.75 19.5 8.25 12l7.5-7.5'/></svg>"), 
+  url, 
+  class: "join-item btn btn-sm btn-ghost hover:bg-base-200 active:bg-transparent", rel: 'prev', remote: true %>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -112,8 +112,3 @@ ja:
   tooltips:
     sweetness: "甘さ: %{percentage}"
     firmness: "固さ: %{percentage}"
-  pagination:
-    previous: "<"
-    next: ">"
-    first: "<<"
-    last: ">>"


### PR DESCRIPTION
## 変更内容
- `_prev_page.html.erb`,`_first_page.html.erb`,`_next_page.html.erb`,`_last_page.html.erb`をアイコンを用いた表示に変更
- ja.ymlに記載していた内容を削除

## 参考
https://www.notion.so/15e9ca21c8058039922bdd1bf22fcae0?pvs=4

## 関連ISSUE
- #217 