### PR TITLE
Fix:ユーザー周りのページにプレースホルダーを追加

### DIFF
--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -9,17 +9,17 @@
 
         <div class="mb-8 sm:mb-10 text-sm sm:text-[16px]">
           <%= f.label :nickname, class: "block font-semibold mb-2 sm:mb-4" %>
-          <%= f.text_field :nickname, class: "input input-bordered w-full bg-white" %>
+          <%= f.text_field :nickname, placeholder: t('users.registrations.nickname_placeholder'), class: "input input-bordered w-full bg-white placeholder:text-sm placeholder:text-placeholder" %>
         </div>
 
         <div class="mb-8 sm:mb-10 text-sm sm:text-[16px]">
           <%= f.label :username, class: "block font-semibold mb-2 sm:mb-4" %>
-          <%= f.text_field :username, class: "input input-bordered w-full bg-white" %>
+          <%= f.text_field :username, placeholder: t('users.registrations.username_placeholder'), class: "input input-bordered w-full bg-white placeholder:text-sm placeholder:text-placeholder" %>
         </div>
 
         <div class="mb-8 sm:mb-10 text-sm sm:text-[16px]">
           <%= f.label :email, class: "block font-semibold mb-2 sm:mb-4" %>
-          <%= f.text_field :email, class: "input input-bordered w-full bg-white" %>
+          <%= f.text_field :email, placeholder: t('users.registrations.email_placeholder'), class: "input input-bordered w-full bg-white placeholder:text-sm placeholder:text-placeholder" %>
         </div>
         
         <div class="mb-8 sm:mb-10 text-sm sm:text-[16px]">
@@ -43,7 +43,7 @@
 
         <div class="mb-8 sm:mb-10 text-sm sm:text-[16px]">
           <%= f.label :comment, class: "block font-semibold mb-2 sm:mb-4" %>
-          <%= f.text_area :comment, class: "textarea textarea-bordered w-full bg-white" %>
+          <%= f.text_area :comment, placeholder: t('users.registrations.comment_placeholder'), class: "textarea textarea-bordered w-full bg-white placeholder:text-sm placeholder:text-placeholder" %>
         </div>
 
         <div class="text-center mt-12 sm:mt-16">

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -9,22 +9,22 @@
         
         <div class="mb-8 sm:mb-10 text-sm sm:text-[16px]">
           <%= f.label :username, class: "block font-semibold mb-2 sm:mb-4" %>
-          <%= f.text_field :username, autofocus: true, class: "input input-bordered w-full bg-white" %>
+          <%= f.text_field :username, autofocus: true, placeholder: t('users.registrations.username_placeholder'), class: "input input-bordered w-full bg-white placeholder:text-sm placeholder:text-placeholder" %>
         </div>
         
         <div class="mb-8 sm:mb-10 text-sm sm:text-[16px]">
           <%= f.label :email, class: "block font-semibold mb-2 sm:mb-4" %>
-          <%= f.email_field :email, class: "input input-bordered w-full bg-white", autocomplete: "email" %>
+          <%= f.email_field :email, placeholder: t('users.registrations.email_placeholder'), class: "input input-bordered w-full bg-white placeholder:text-sm placeholder:text-placeholder", autocomplete: "email" %>
         </div>
 
         <div class="mb-8 sm:mb-10 text-sm sm:text-[16px]">
           <%= f.label :password, class: "block font-semibold mb-2 sm:mb-4" %>
-          <%= f.password_field :password, class: "input input-bordered w-full bg-white", autocomplete: "new-password" %>
+          <%= f.password_field :password, placeholder: t('users.registrations.password_placeholder'), class: "input input-bordered w-full bg-white placeholder:text-sm placeholder:text-placeholder", autocomplete: "new-password" %>
         </div>
 
         <div class="mb-8 sm:mb-10 text-sm sm:text-[16px]">
           <%= f.label :password_confirmation, class: "block font-semibold mb-2 sm:mb-4" %>
-          <%= f.password_field :password_confirmation, class: "input input-bordered w-full bg-white", autocomplete: "new-password" %>
+          <%= f.password_field :password_confirmation, placeholder: t('users.registrations.password_confirmation_placeholder'), class: "input input-bordered w-full bg-white placeholder:text-sm placeholder:text-placeholder", autocomplete: "new-password" %>
         </div>
 
         <div class="text-center my-10 mt-8 sm:mt-12">

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -9,12 +9,12 @@
 
         <div class="mb-8 sm:mb-10 text-sm sm:text-[16px]">
           <%= f.label :email, class: "block font-semibold mb-2 sm:mb-4" %>
-          <%= f.email_field :email, autofocus: true, class: "input input-bordered w-full bg-white", autocomplete: "email" %>
+          <%= f.email_field :email, autofocus: true, placeholder: t('users.sessions.email_placeholder'), class: "input input-bordered w-full bg-white placeholder:text-sm placeholder:text-placeholder", autocomplete: "email" %>
         </div>
         
         <div class="mb-2 sm:mb-4 text-sm sm:text-[16px]">
           <%= f.label :password, class: "block font-semibold mb-2 sm:mb-4" %>
-          <%= f.password_field :password, class: "input input-bordered w-full bg-white", autocomplete: "current-password" %>
+          <%= f.password_field :password, placeholder: t('users.sessions.password_placeholder'), class: "input input-bordered w-full bg-white placeholder:text-sm placeholder:text-placeholder", autocomplete: "current-password" %>
         </div>
 
         <% if devise_mapping.rememberable? %>

--- a/config/locales/devise.views.ja.yml
+++ b/config/locales/devise.views.ja.yml
@@ -28,7 +28,7 @@ ja:
         username: ユーザー名
         nickname: 名前
         avatar: プロフィール画像
-        comment: 自己紹介
+        comment: プリン愛
         preferred_sweetness: 甘さの好み
         preferred_firmness: 固さの好み
     models:

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -87,14 +87,15 @@ ja:
     exclusion_message: 'は使用できません'
     not_found: 'ユーザーが見つかりませんでした'
     sessions:
-      email_placeholder: '例：example@email.com'
+      email_placeholder: '例：pudding.is.life@caramel.heaven'
       password_placeholder: '半角英数字記号(6文字以上)'
     registrations:
       username_placeholder: '半角英数字および記号(._-~)'
-      email_placeholder: '例：example@email.com'
+      email_placeholder: '例：i.love.pudding@sweet.and.smooth'
       password_placeholder: '半角英数字記号(6文字以上)'
       password_confirmation_placeholder: 'パスワードを再入力'
-      
+      nickname_placeholder: 'プリン界の異名（例：甘党戦士ぷるるん丸）'
+      comment_placeholder: 'プリンに対する熱い思い（例：固まらないプリンは人生）'
     show:
       no_posts: 投稿はありません
   maps:

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -88,7 +88,13 @@ ja:
     not_found: 'ユーザーが見つかりませんでした'
     sessions:
       email_placeholder: '例：example@email.com'
-      password_placeholder: '半角英数字(6文字以上)'
+      password_placeholder: '半角英数字記号(6文字以上)'
+    registrations:
+      username_placeholder: '半角英数字および記号(._-~)'
+      email_placeholder: '例：example@email.com'
+      password_placeholder: '半角英数字記号(6文字以上)'
+      password_confirmation_placeholder: 'パスワードを再入力'
+      
     show:
       no_posts: 投稿はありません
   maps:

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -86,6 +86,9 @@ ja:
     nickname_format: 'は半角英数字、アンダースコア、ハイフン、ピリオド、チルドのみ使用できます'
     exclusion_message: 'は使用できません'
     not_found: 'ユーザーが見つかりませんでした'
+    sessions:
+      email_placeholder: '例：example@email.com'
+      password_placeholder: '半角英数字(6文字以上)'
     show:
       no_posts: 投稿はありません
   maps:

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe 'Users', type: :system do
           select 'かため', from: '固さの好み'
           # 画像ファイルを指定してアップロード
           attach_file('プロフィール画像', Rails.root.join('spec/fixtures/test_image.jpg'))
-          fill_in '自己紹介', with: 'a' * 10
+          fill_in 'プリン愛', with: 'a' * 10
           click_button '更新'
           expect(page).to have_content 'プロフィールを更新しました'
           expect(current_path).to eq mypage_mypage_path
@@ -128,7 +128,7 @@ RSpec.describe 'Users', type: :system do
           select 'かため', from: '固さの好み'
           # 画像ファイルを指定してアップロード
           attach_file('プロフィール画像', Rails.root.join('spec/fixtures/test_image.jpg'))
-          fill_in '自己紹介', with: 'a' * 10
+          fill_in 'プリン愛', with: 'a' * 10
           click_button '更新'
           expect(page).to have_content 'プロフィールを更新しました'
           expect(current_path).to eq mypage_mypage_path
@@ -145,7 +145,7 @@ RSpec.describe 'Users', type: :system do
           select 'かため', from: '固さの好み'
           # 画像ファイルを指定してアップロード
           attach_file('プロフィール画像', Rails.root.join('spec/fixtures/test_image.jpg'))
-          fill_in '自己紹介', with: 'a' * 10
+          fill_in 'プリン愛', with: 'a' * 10
           click_button '更新'
           expect(page).to have_content 'エラーが発生したため ユーザー は保存されませんでした'
           expect(page).to have_content 'ユーザー名を入力してください'
@@ -163,7 +163,7 @@ RSpec.describe 'Users', type: :system do
           select 'かため', from: '固さの好み'
           # 画像ファイルを指定してアップロード
           attach_file('プロフィール画像', Rails.root.join('spec/fixtures/test_image.jpg'))
-          fill_in '自己紹介', with: 'a' * 10
+          fill_in 'プリン愛', with: 'a' * 10
           click_button '更新'
           expect(page).to have_content 'エラーが発生したため ユーザー は保存されませんでした'
           expect(page).to have_content 'メールアドレスを入力してください'
@@ -181,7 +181,7 @@ RSpec.describe 'Users', type: :system do
           select 'かため', from: '固さの好み'
           # 画像ファイルを指定してアップロード
           attach_file('プロフィール画像', Rails.root.join('spec/fixtures/test_image.jpg'))
-          fill_in '自己紹介', with: 'a' * 10
+          fill_in 'プリン愛', with: 'a' * 10
           click_button '更新'
           expect(page).to have_content 'プロフィールを更新しました'
           expect(current_path).to eq mypage_mypage_path
@@ -198,7 +198,7 @@ RSpec.describe 'Users', type: :system do
           select '未設定', from: '固さの好み'
           # 画像ファイルを指定してアップロード
           attach_file('プロフィール画像', Rails.root.join('spec/fixtures/test_image.jpg'))
-          fill_in '自己紹介', with: 'a' * 10
+          fill_in 'プリン愛', with: 'a' * 10
           click_button '更新'
           expect(page).to have_content 'プロフィールを更新しました'
           expect(current_path).to eq mypage_mypage_path
@@ -213,14 +213,14 @@ RSpec.describe 'Users', type: :system do
           fill_in 'メールアドレス', with: 'update@example.com'
           select 'ほどよい', from: '甘さの好み'
           select 'かため', from: '固さの好み'
-          fill_in '自己紹介', with: 'a' * 10
+          fill_in 'プリン愛', with: 'a' * 10
           click_button '更新'
           expect(page).to have_content 'プロフィールを更新しました'
           expect(current_path).to eq mypage_mypage_path
         end
       end
 
-      context '自己紹介が未入力' do
+      context 'プリン愛が未入力' do
         it 'ユーザーの編集が成功する' do
           visit edit_user_registration_path
           fill_in '名前', with: 'テストユーザー'
@@ -230,7 +230,7 @@ RSpec.describe 'Users', type: :system do
           select 'かため', from: '固さの好み'
           # 画像ファイルを指定してアップロード
           attach_file('プロフィール画像', Rails.root.join('spec/fixtures/test_image.jpg'))
-          fill_in '自己紹介', with: ''
+          fill_in 'プリン愛', with: ''
           click_button '更新'
           expect(page).to have_content 'プロフィールを更新しました'
           expect(current_path).to eq mypage_mypage_path
@@ -248,7 +248,7 @@ RSpec.describe 'Users', type: :system do
           select 'かため', from: '固さの好み'
           # 画像ファイルを指定してアップロード
           attach_file('プロフィール画像', Rails.root.join('spec/fixtures/test_image.jpg'))
-          fill_in '自己紹介', with: 'a' * 10
+          fill_in 'プリン愛', with: 'a' * 10
           click_button '更新'
           expect(page).to have_content 'エラーが発生したため ユーザー は保存されませんでした'
           expect(page).to have_content 'ユーザー名はすでに存在します'
@@ -267,7 +267,7 @@ RSpec.describe 'Users', type: :system do
           select 'かため', from: '固さの好み'
           # 画像ファイルを指定してアップロード
           attach_file('プロフィール画像', Rails.root.join('spec/fixtures/test_image.jpg'))
-          fill_in '自己紹介', with: 'a' * 10
+          fill_in 'プリン愛', with: 'a' * 10
           click_button '更新'
           expect(page).to have_content 'エラーが発生したため ユーザー は保存されませんでした'
           expect(page).to have_content 'メールアドレスはすでに存在します'


### PR DESCRIPTION
## 変更内容
- ログインページにプレースホルダーを追加
- 新規登録ページにプレースホルダーを追加
- ユーザー編集ページにプレースホルダーを追加
- user.commentの日本語を変更
- 上記に基づきテストコードを修正

## テスト結果
- **rspec**
[![Image from Gyazo](https://i.gyazo.com/ccb3e14455c4a4f26788bed261e16a88.png)](https://gyazo.com/ccb3e14455c4a4f26788bed261e16a88)

- **lintチェック**
[![Image from Gyazo](https://i.gyazo.com/9450a6de57a78fcd44176eff4a45acfc.png)](https://gyazo.com/9450a6de57a78fcd44176eff4a45acfc)


## 関連ISSUE
- #305 
