### PR TITLE
Fix:各ページの余白,文字サイズの調整

### DIFF
--- a/app/views/maps/index.html.erb
+++ b/app/views/maps/index.html.erb
@@ -101,25 +101,25 @@ function setShopMarkers() {
         const modalContent = `
         <% if user_signed_in? %>
           <div class="flex justify-end mb-2">
-            <div class="flex items-center mr-1">
-              <div class="mr-1">
+            <div class="flex items-center">
+              <div>
                 <%= render 'posts/like_buttons', { post: post } %>
               </div>
-              <div class="text-xs text-gray-500 w-[2ch] text-left cursor-pointer hover:underline" onclick="like_modal_<%= post.id %>.showModal()" id="like-count-<%= post.id %>">
+              <div class="text-xs text-gray-500 w-[2ch] text-left pr-4 cursor-pointer hover:underline" onclick="like_modal_<%= post.id %>.showModal()" id="like-count-<%= post.id %>">
                 <%= post.likes.count %>
               </div>
               <%= render 'posts/like_modal', post: post %>
             </div>
             <% if post.user != current_user %>
-              <div class="sm:mr-3">
+              <div>
                 <%= render 'posts/bookmark_buttons', { post: post } %>
               </div>
             <% end %>
           </div>
         <% else %>
           <div class="flex items-center justify-end mb-2">
-            <div class="text-sweetDeep mr-1">
-              <i class="far fa-heart text-[18px] sm:text-[20px]"></i>
+            <div class="text-sweetDeep">
+              <i class="far fa-heart text-[18px] sm:text-[20px] pl-0.5 pr-1.5"></i>
             </div>
             <div class="text-xs text-gray-500 w-[2ch] text-left" id="like-count-<%= post.id %>">
               <%= post.likes.count %>

--- a/app/views/maps/index.html.erb
+++ b/app/views/maps/index.html.erb
@@ -132,12 +132,12 @@ function setShopMarkers() {
         </div>
         <div class='flex justify-center'>
           <% if post.image.present? %>
-            <%= image_tag post.image.variant(resize_to_fill: [800, 800], format: :webp), class: 'object-cover w-60 h-60 mt-3' %>
+            <%= image_tag post.image.variant(resize_to_fill: [800, 800], format: :webp), class: 'object-cover w-60 h-60 mt-2 sm:mt-3' %>
           <% else %>
           <% end %>
         </div>
-        <div class='flex flex-col items-center justify-center mt-4'>
-          <div class="mb-4 flex justify-center space-x-1">
+        <div class='flex flex-col items-center justify-center mt-2 sm:mt-3'>
+          <div class="mb-1 flex justify-center space-x-1">
             <% Post.overall_ratings.size.times do |i| %>
               <span 
                 class="inline-block w-6 h-6 sm:w-7 sm:h-7 mask mask-star-2 <%= i < Post.overall_ratings[post.overall_rating] ? 'bg-accent' : 'bg-placeholder' %>"
@@ -148,22 +148,22 @@ function setShopMarkers() {
           <div class="flex flex-wrap items-center mb-3 text-sm sm:text-[18px] text-center sm:text-left">
             <div class="flex items-center">
               <div class="tooltip" data-tip="<%= t("tooltips.sweetness", percentage: post.sweetness_percentage) %>">
-                <span class="badge text-xs sm:text-sm py-2 sm:py-2.5 <%= sweetness_badge_color(post.sweetness) %> mr-0.5 sm:mr-1"><%= t("enums.post.sweetness.#{post.sweetness}") %></span>
+                <span class="badge text-[10px] sm:text-xs py-2 sm:py-2.5 <%= sweetness_badge_color(post.sweetness) %> mr-0.5 sm:mr-1"><%= t("enums.post.sweetness.#{post.sweetness}") %></span>
               </div>
             </div>
             <div class="flex items-center">
               <div class="tooltip" data-tip="<%= t("tooltips.firmness", percentage: post.firmness_percentage) %>">
-                <span class="badge text-xs sm:text-sm py-2 sm:py-2.5 <%= firmness_badge_color(post.firmness) %>"><%= t("enums.post.firmness.#{post.firmness}") %></span>
+                <span class="badge text-[10px] sm:text-xs py-2 sm:py-2.5 <%= firmness_badge_color(post.firmness) %>"><%= t("enums.post.firmness.#{post.firmness}") %></span>
               </div>
             </div>
           </div>
         </div>
         <div class="flex items-center justify-center">
           <div class="text-left max-w-md mx-4 sm:mx-6">
-            <p class="my-2 text-sm sm:text-[16px] text-subtleText">
+            <p class="text-sm sm:text-[16px] text-subtleText">
               <i class="fa fa-map-marker-alt mr-2 text-accent"></i><%= post.shop.address %>
             </p>
-            <div class='my-3 text-text text-opacity-80'>
+            <div class='my-2 sm:my-3 text-text text-opacity-80'>
               <p><%= post.body.truncate(55) %></p>
             </div>
           </div>

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -43,12 +43,12 @@
             <% end %>
           </div>
         </div>
-        <div class="w-full sm:w-3/5 px-4 pt-4">
+        <div class="w-full sm:w-3/5 px-4 pt-2 sm:pt-4 sm:pb-0">
           <h2 class="text-xs md:text-sm text-subtleText mt-2 mb-1 text-center sm:text-left"><%= t("enums.post.category.#{post.category}") %></h2>
-          <h1 class="text-xl sm:text-2xl font-bold mb-3 text-center sm:text-left">
+          <h1 class="text-xl sm:text-2xl font-bold mb-2 sm:mb-3 text-center sm:text-left">
             <%= link_to post.shop.name, post_path(post), data: { turbo: false } %>
           </h1>
-          <div class="flex justify-center sm:justify-start mb-4 space-x-1">
+          <div class="flex justify-center sm:justify-start mb-1 space-x-1">
             <% Post.overall_ratings.size.times do |i| %>
               <span 
                 class="inline-block w-6 h-6 sm:w-7 sm:h-7 mask mask-star-2 <%= i < Post.overall_ratings[post.overall_rating] ? 'bg-accent' : 'bg-placeholder' %>"
@@ -56,43 +56,43 @@
               ></span>
             <% end %>
           </div>
-          <div class="flex flex-wrap justify-center sm:justify-start items-center mb-3 text-sm sm:text-[18px] text-center sm:text-left">
+          <div class="flex flex-wrap justify-center sm:justify-start items-center mb-2 sm:mb-3 text-sm sm:text-[18px] text-center sm:text-left">
             <div class="flex items-center">
               <div class="tooltip" data-tip="<%= t("tooltips.sweetness", percentage: post.sweetness_percentage) %>">
-                <span class="badge text-xs sm:text-sm py-2 sm:py-2.5 <%= sweetness_badge_color(post.sweetness) %> mr-0.5 sm:mr-1"><%= t("enums.post.sweetness.#{post.sweetness}") %></span>
+                <span class="badge text-[10px] sm:text-xs py-2 sm:py-2.5 <%= sweetness_badge_color(post.sweetness) %> mr-0.5 sm:mr-1"><%= t("enums.post.sweetness.#{post.sweetness}") %></span>
               </div>
             </div>
             <div class="flex items-center">
               <div class="tooltip" data-tip="<%= t("tooltips.firmness", percentage: post.firmness_percentage) %>">
-                <span class="badge text-xs sm:text-sm py-2 sm:py-2.5 <%= firmness_badge_color(post.firmness) %>"><%= t("enums.post.firmness.#{post.firmness}") %></span>
+                <span class="badge text-[10px] sm:text-xs py-2 sm:py-2.5 <%= firmness_badge_color(post.firmness) %>"><%= t("enums.post.firmness.#{post.firmness}") %></span>
               </div>
             </div>
           </div>
           <% if post.shop&.address.present? %>
-            <p class="mb-2 sm:ml-1 text-sm sm:text-[16px] text-subtleText">
+            <p class="mb-2 sm:mb-3 sm:ml-1 text-sm sm:text-[16px] text-subtleText">
               <i class="fa fa-map-marker-alt mr-2 text-accent"></i><%= post.shop.address %>
             </p> 
           <% end %>
           <p class="sm:ml-0.5 text-sm sm:text-[16px] text-text text-opacity-80"><%= post.body.truncate(44) %></p>
           <!-- いいね -->
           <% if user_signed_in? %>
-            <div class="flex justify-start ml-0.5 mt-2">
+            <div class="flex justify-start ml-0.5 mt-2 sm:mt-3">
               <div class="flex items-center mr-1">
                 <div class="mr-1">
                   <%= render 'posts/like_buttons', { post: post } %>
                 </div>
-                <div class="text-xs text-gray-500 w-[2ch] text-left cursor-pointer hover:underline" onclick="like_modal_<%= post.id %>.showModal()" id="like-count-<%= post.id %>">
+                <div class="text-xs text-gray-500 w-[2ch] text-left pl-0.5 pr-6 cursor-pointer hover:underline" onclick="like_modal_<%= post.id %>.showModal()" id="like-count-<%= post.id %>">
                   <%= post.likes.count %>
                 </div>
                 <%= render 'posts/like_modal', post: post %>
               </div>
             </div>
           <% else %>
-            <div class="flex items-center justify-start ml-0.5 mt-2">
+            <div class="flex items-center justify-start ml-0.5 mt-2 sm:mt-3">
               <div class="text-sweetDeep mr-1">
                 <i class="far fa-heart text-[18px] sm:text-[20px]"></i>
               </div>
-              <div class="text-xs text-gray-500 w-[2ch] text-left">
+              <div class="text-xs text-gray-500 w-[2ch] text-left pl-0.5 pr-6">
                 <%= post.likes.count %>
               </div>
             </div>

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -76,23 +76,23 @@
           <p class="sm:ml-0.5 text-sm sm:text-[16px] text-text text-opacity-80"><%= post.body.truncate(44) %></p>
           <!-- いいね -->
           <% if user_signed_in? %>
-            <div class="flex justify-start ml-0.5 mt-2 sm:mt-3">
-              <div class="flex items-center mr-1">
-                <div class="mr-1">
+            <div class="flex justify-start mt-2 sm:mt-3">
+              <div class="flex items-center">
+                <div>
                   <%= render 'posts/like_buttons', { post: post } %>
                 </div>
-                <div class="text-xs text-gray-500 w-[2ch] text-left pl-0.5 pr-6 cursor-pointer hover:underline" onclick="like_modal_<%= post.id %>.showModal()" id="like-count-<%= post.id %>">
+                <div class="text-xs text-gray-500 w-[2ch] text-left pr-5 cursor-pointer hover:underline" onclick="like_modal_<%= post.id %>.showModal()" id="like-count-<%= post.id %>">
                   <%= post.likes.count %>
                 </div>
                 <%= render 'posts/like_modal', post: post %>
               </div>
             </div>
           <% else %>
-            <div class="flex items-center justify-start ml-0.5 mt-2 sm:mt-3">
-              <div class="text-sweetDeep mr-1">
-                <i class="far fa-heart text-[18px] sm:text-[20px]"></i>
+            <div class="flex items-center justify-start mt-2 sm:mt-3">
+              <div class="text-sweetDeep">
+                <i class="far fa-heart text-[18px] sm:text-[20px] pl-0.5 pr-1.5"></i>
               </div>
-              <div class="text-xs text-gray-500 w-[2ch] text-left pl-0.5 pr-6">
+              <div class="text-xs text-gray-500 w-[2ch] text-left">
                 <%= post.likes.count %>
               </div>
             </div>

--- a/app/views/posts/_to_like.html.erb
+++ b/app/views/posts/_to_like.html.erb
@@ -1,3 +1,3 @@
 <%= link_to post_likes_path(post_id: post.id), id: "like-button-for-post-#{post.id}", data: { turbo_method: :post }, class: "text-sweetDeep focus:outline-none focus-visible:outline-none" do %>
-  <i class="far fa-heart text-[18px] sm:text-[20px]"></i>
+  <i class="far fa-heart text-[18px] sm:text-[20px] pl-0.5 pr-1.5"></i>
 <% end %>

--- a/app/views/posts/_to_unlike.html.erb
+++ b/app/views/posts/_to_unlike.html.erb
@@ -1,3 +1,3 @@
 <%= link_to post_like_path(post_id: post.id, id: current_user.likes.find_by(post_id: post.id).id), id: "unlike-button-for-post-#{post.id}", data: { turbo_method: :delete }, class: "text-sweetDeep focus:outline-none focus-visible:outline-none" do %>
-  <i class="fas fa-heart text-[18px] sm:text-[20px]"></i>
+  <i class="fas fa-heart text-[18px] sm:text-[20px] pl-0.5 pr-1.5"></i>
 <% end %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -53,11 +53,11 @@
     <!-- ブックマークといいね -->
     <% if user_signed_in? %>
       <div class="flex justify-end mb-2 sm:mb-4 px-4 sm:px-6">
-        <div class="flex items-center mr-1">
-          <div class="mr-1">
+        <div class="flex items-center">
+          <div>
             <%= render 'posts/like_buttons', { post: @post } %>
           </div>
-          <div class="text-xs text-gray-500 w-[2ch] text-left cursor-pointer hover:underline" onclick="like_modal_<%= @post.id %>.showModal()" id="like-count-<%= @post.id %>">
+          <div class="text-xs text-gray-500 w-[2ch] text-left pr-4 cursor-pointer hover:underline" onclick="like_modal_<%= @post.id %>.showModal()" id="like-count-<%= @post.id %>">
             <%= @post.likes.count %>
           </div>
           <%= render 'posts/like_modal', post: @post %>
@@ -70,10 +70,10 @@
       </div>
     <% else %>
       <div class="flex items-center justify-end mb-2 sm:mb-4 px-6">
-        <div class="text-sweetDeep mr-1">
-          <i class="far fa-heart text-[18px] sm:text-[20px]"></i>
+        <div class="text-sweetDeep">
+          <i class="far fa-heart text-[18px] sm:text-[20px] pl-0.5 pr-1.5"></i>
         </div>
-        <div class="text-xs text-gray-500 w-[2ch] text-left" id="like-count-<%= @post.id %>">
+        <div class="text-xs text-gray-500 w-[2ch] text-left pr-4" id="like-count-<%= @post.id %>">
           <%= @post.likes.count %>
         </div>
       </div>

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -1,5 +1,5 @@
 <div class="flex flex-col items-center p-6">
-  <h1 class="text-5xl sm:text-7xl font-bold font-rounded text-accent pt-40"><%= t('.title') %></h1>
+  <h1 class="text-5xl sm:text-7xl font-bold font-rounded text-accent pt-32"><%= t('.title') %></h1>
   <p class="text-sm sm:text-lg pt-6"><%= t('.sub_title') %></p>
   <div class="pt-8 flex justify-betweet space-x-4 sm:space-x-8 items-center">
     <%= link_to t('.start'), posts_path, class: "btn btn-primary rounded-lg py-2 sm:py-3 text-xs sm:text-sm text-textLight"%>
@@ -15,13 +15,13 @@
     
     <div class="space-y-2">
       <p>
-        人気店の定番から、まだ知られていない素敵なお店まで。<br>
+        人気店から、まだ知られていない素敵なお店まで。<br>
         写真だけでは伝わらない、食感や味わいの違いを詳しくご紹介。
       </p>
       
       <p>
-        固さ、甘さ、みんなのレビューなど、細かな情報で比較できるから、<br>
-        好みのプリンが簡単に見つかります。
+        固さ、甘さ、みんなのレビューなど、<br>
+        細かな情報で比較できるため、好みのプリンが簡単に見つかります。
       </p>
       
       <p>
@@ -31,13 +31,13 @@
     </div>
     
     <p class="font-medium">
-      新しい「おいしい！」との出会いをサポートします。
+      あなたの「運命のプリン」との出会いをサポートします。
     </p>
   </div>
 </div>
 
 <%# 未ログインでできること %>
-<div class="w-5/6 mx-auto max-w-sm sm:max-w-5xl mt-40 mb-20">
+<div class="w-5/6 mx-auto max-w-sm sm:max-w-5xl mt-44 mb-20">
   <div class="flex items-center justify-center mb-3">
     <h2 class="text-sm sm:text-[16px] text-center text-primary font-bold">
       <%= t('.without_login.title') %>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -87,11 +87,11 @@ ja:
     exclusion_message: 'は使用できません'
     not_found: 'ユーザーが見つかりませんでした'
     sessions:
-      email_placeholder: '例：pudding.is.life@caramel.heaven'
+      email_placeholder: '例：pudding.is.life@email.com'
       password_placeholder: '半角英数字記号(6文字以上)'
     registrations:
       username_placeholder: '半角英数字および記号(._-~)'
-      email_placeholder: '例：i.love.pudding@sweet.and.smooth'
+      email_placeholder: '例：pudding.is.life@email.com'
       password_placeholder: '半角英数字記号(6文字以上)'
       password_confirmation_placeholder: 'パスワードを再入力'
       nickname_placeholder: 'プリン界の異名（例：甘党戦士ぷるるん丸）'


### PR DESCRIPTION
## 変更内容
### トップページ
- ロゴ上部の余白を修正
- 一部文言を修正

### 一覧ページ
- いいねボタンといいね数リンクにpaddingを追加
- まとまりごとに余白が揃うように修正
- 文字サイズの修正

### 詳細ページ
- いいねボタンといいね数リンクにpaddingを追加
- まとまりごとに余白が揃うように修正
- 文字サイズの修正

### マップページ内のモーダル
- いいねボタンといいね数リンクにpaddingを追加
- まとまりごとに余白が揃うように修正
- 文字サイズの修正

### その他
- プレースホルダーの文言を修正


## テスト結果
- **rspec**
[![Image from Gyazo](https://i.gyazo.com/55816a9dc2ce493c387fd1445e686231.png)](https://gyazo.com/55816a9dc2ce493c387fd1445e686231)

## 関連ISSUE
- #306 

## 備忘
ISSUEにあるマップに関する修正が別途修正予定